### PR TITLE
Add telemetry integration and command panel updates

### DIFF
--- a/src/main/java/com/alechilles/alecstamework/Tamework.java
+++ b/src/main/java/com/alechilles/alecstamework/Tamework.java
@@ -50,6 +50,8 @@ import com.alechilles.alecstamework.interactions.TameworkLaunchProjectileInterac
 import com.alechilles.alecstamework.interactions.TameworkNameNpcInteraction;
 import com.alechilles.alecstamework.interactions.TameworkSpawnInteraction;
 import com.alechilles.alecstamework.integration.nameplatebuilder.NameplateBuilderBridgeLoader;
+import com.alechilles.alecstamework.integration.telemetry.AlecsTelemetryBridgeLoader;
+import com.alechilles.alecstamework.integration.telemetry.AlecsTelemetryBridgeLoader.AlecsTelemetryBridge;
 import com.alechilles.alecstamework.integration.tooltips.SpawnerTooltipBridge;
 import com.alechilles.alecstamework.integration.tooltips.SpawnerTooltipBridgeLoader;
 import com.alechilles.alecstamework.items.CommandItemFeatureHandler;
@@ -155,6 +157,8 @@ import com.hypixel.hytale.server.npc.entities.NPCEntity;
  */
 public class Tamework extends JavaPlugin {
 
+    private static final String ALECS_TELEMETRY_PROJECT_ID = "alecs-tamework";
+
     private static Tamework instance;
 
     private ItemFeatureRegistry itemFeatureRegistry;
@@ -187,6 +191,7 @@ public class Tamework extends JavaPlugin {
     private TameworkNpcBuilderRegistrar npcBuilderRegistrar;
     private TameworkHStatsIntegration hStatsIntegration;
     private CrashTelemetryService crashTelemetryService;
+    private AlecsTelemetryBridge alecsTelemetryBridge;
     private TameworkSettingsAnnouncementService settingsAnnouncementService;
     private SpawnerTooltipBridge spawnerTooltipBridge;
     private boolean globalAssetsRegistered;
@@ -248,10 +253,13 @@ public class Tamework extends JavaPlugin {
     @Override
     protected void setup() {
         initializeCrashTelemetry();
+        alecsTelemetryBridge = AlecsTelemetryBridgeLoader.initialize(getLogger(), ALECS_TELEMETRY_PROJECT_ID);
         try {
             setupInternal();
+            recordAlecsTelemetryBreadcrumb("lifecycle", "Tamework setup completed.");
         } catch (Throwable throwable) {
             captureSetupFailure(throwable);
+            captureAlecsTelemetrySetupFailure(throwable);
             throw throwable;
         }
     }
@@ -717,8 +725,10 @@ public class Tamework extends JavaPlugin {
     protected void start() {
         try {
             startInternal();
+            recordAlecsTelemetryBreadcrumb("lifecycle", "Tamework start completed.");
         } catch (Throwable throwable) {
             captureStartFailure(throwable);
+            captureAlecsTelemetryStartFailure(throwable);
             throw throwable;
         }
     }
@@ -763,6 +773,7 @@ public class Tamework extends JavaPlugin {
         apiSelfTestFixtureManager = null;
         apiSelfTestRunner = null;
         crashTelemetryService = null;
+        alecsTelemetryBridge = null;
         settingsAnnouncementService = null;
         getLogger().at(Level.INFO).log("Alec's Tamework! has been disabled!");
     }
@@ -791,6 +802,27 @@ public class Tamework extends JavaPlugin {
             return;
         }
         crashTelemetryService.captureStartFailure(throwable);
+    }
+
+    private void captureAlecsTelemetrySetupFailure(@Nullable Throwable throwable) {
+        if (alecsTelemetryBridge == null || throwable == null) {
+            return;
+        }
+        alecsTelemetryBridge.captureSetupFailure(throwable);
+    }
+
+    private void captureAlecsTelemetryStartFailure(@Nullable Throwable throwable) {
+        if (alecsTelemetryBridge == null || throwable == null) {
+            return;
+        }
+        alecsTelemetryBridge.captureStartFailure(throwable);
+    }
+
+    private void recordAlecsTelemetryBreadcrumb(@Nonnull String category, @Nonnull String detail) {
+        if (alecsTelemetryBridge == null) {
+            return;
+        }
+        alecsTelemetryBridge.recordBreadcrumb(category, detail);
     }
 
     private void onWorldRemovedForCrashTelemetry(@Nonnull RemoveWorldEvent event) {

--- a/src/main/java/com/alechilles/alecstamework/integration/telemetry/AlecsTelemetryBridgeLoader.java
+++ b/src/main/java/com/alechilles/alecstamework/integration/telemetry/AlecsTelemetryBridgeLoader.java
@@ -1,0 +1,128 @@
+package com.alechilles.alecstamework.integration.telemetry;
+
+import com.hypixel.hytale.logger.HytaleLogger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.reflect.Method;
+import java.util.logging.Level;
+
+/**
+ * Loads the optional Alec's Telemetry runtime API when it is present.
+ */
+public final class AlecsTelemetryBridgeLoader {
+
+    private static final String LOCATOR_CLASS = "com.alechilles.alecstelemetry.api.TelemetryRuntimeLocator";
+
+    private AlecsTelemetryBridgeLoader() {
+    }
+
+    @Nonnull
+    public static AlecsTelemetryBridge initialize(@Nullable HytaleLogger logger, @Nonnull String projectId) {
+        if (!isApiPresent()) {
+            return NoOpAlecsTelemetryBridge.INSTANCE;
+        }
+        if (logger != null) {
+            logger.at(Level.INFO).log("Alec's Telemetry integration detected.");
+        }
+        return new ReflectiveAlecsTelemetryBridge(projectId, logger);
+    }
+
+    private static boolean isApiPresent() {
+        try {
+            Class.forName(LOCATOR_CLASS);
+            return true;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    /**
+     * Tiny optional bridge surface used by Tamework.
+     */
+    public interface AlecsTelemetryBridge {
+        void recordBreadcrumb(@Nonnull String category, @Nonnull String detail);
+
+        void captureSetupFailure(@Nullable Throwable throwable);
+
+        void captureStartFailure(@Nullable Throwable throwable);
+    }
+
+    private enum NoOpAlecsTelemetryBridge implements AlecsTelemetryBridge {
+        INSTANCE;
+
+        @Override
+        public void recordBreadcrumb(@Nonnull String category, @Nonnull String detail) {
+        }
+
+        @Override
+        public void captureSetupFailure(@Nullable Throwable throwable) {
+        }
+
+        @Override
+        public void captureStartFailure(@Nullable Throwable throwable) {
+        }
+    }
+
+    private static final class ReflectiveAlecsTelemetryBridge implements AlecsTelemetryBridge {
+
+        private final String projectId;
+        private final HytaleLogger logger;
+
+        private ReflectiveAlecsTelemetryBridge(@Nonnull String projectId, @Nullable HytaleLogger logger) {
+            this.projectId = projectId;
+            this.logger = logger;
+        }
+
+        @Override
+        public void recordBreadcrumb(@Nonnull String category, @Nonnull String detail) {
+            invokeProjectHandleMethod("recordBreadcrumb", new Class<?>[]{String.class, String.class}, category, detail);
+        }
+
+        @Override
+        public void captureSetupFailure(@Nullable Throwable throwable) {
+            if (throwable == null) {
+                return;
+            }
+            invokeProjectHandleMethod("captureSetupFailure", new Class<?>[]{Throwable.class}, throwable);
+        }
+
+        @Override
+        public void captureStartFailure(@Nullable Throwable throwable) {
+            if (throwable == null) {
+                return;
+            }
+            invokeProjectHandleMethod("captureStartFailure", new Class<?>[]{Throwable.class}, throwable);
+        }
+
+        private void invokeProjectHandleMethod(@Nonnull String methodName,
+                                               @Nonnull Class<?>[] parameterTypes,
+                                               @Nonnull Object... args) {
+            try {
+                Object projectHandle = resolveProjectHandle();
+                if (projectHandle == null) {
+                    return;
+                }
+                Method method = projectHandle.getClass().getMethod(methodName, parameterTypes);
+                method.invoke(projectHandle, args);
+            } catch (Throwable ex) {
+                if (logger != null) {
+                    logger.at(Level.WARNING).withCause(ex)
+                            .log("Alec's Telemetry integration failed while calling " + methodName + " for " + projectId + ".");
+                }
+            }
+        }
+
+        @Nullable
+        private Object resolveProjectHandle() throws Exception {
+            Class<?> locatorClass = Class.forName(LOCATOR_CLASS);
+            Method tryGet = locatorClass.getMethod("tryGet");
+            Object runtimeApi = tryGet.invoke(null);
+            if (runtimeApi == null) {
+                return null;
+            }
+            Method findProject = runtimeApi.getClass().getMethod("findProject", String.class);
+            return findProject.invoke(runtimeApi, projectId);
+        }
+    }
+}

--- a/src/main/java/com/alechilles/alecstamework/items/CommandItemFeatureHandler.java
+++ b/src/main/java/com/alechilles/alecstamework/items/CommandItemFeatureHandler.java
@@ -710,6 +710,7 @@ public final class CommandItemFeatureHandler {
                 selectedId,
                 requireUnlinkConfirm,
                 () -> toolInventoryService.buildLinkedPanelEntriesForTool(player, toolId, config),
+                () -> toolInventoryService.buildLinkedPanelBaseEntriesForTool(player, toolId, config),
                 () -> toolInventoryService.resolvePanelModeValueForTool(player, toolId, config),
                 () -> toolInventoryService.resolvePanelRadiusLabelForTool(player, toolId, config),
                 () -> toolInventoryService.resolvePanelSortValueForTool(player, toolId),

--- a/src/main/java/com/alechilles/alecstamework/items/CommandToolInventoryService.java
+++ b/src/main/java/com/alechilles/alecstamework/items/CommandToolInventoryService.java
@@ -105,6 +105,10 @@ final class CommandToolInventoryService {
         return buildLinkedPanelEntriesForTool(player, toolId, null);
     }
 
+    List<LinkedNpcEntry> buildLinkedPanelBaseEntriesForTool(Player player, String toolId) {
+        return buildLinkedPanelBaseEntriesForTool(player, toolId, null);
+    }
+
     List<LinkedNpcEntry> buildLinkedPanelEntriesForTool(Player player,
                                                         String toolId,
                                                         com.alechilles.alecstamework.config.assets.TwCommandItemConfig config) {
@@ -138,6 +142,44 @@ final class CommandToolInventoryService {
                 return panelEntrySourceService.buildEntries(player, store, stack, config, toolId);
             }
             return panelEntryService.buildEntries(player, store, stack, toolId);
+        }
+        return List.of();
+    }
+
+    List<LinkedNpcEntry> buildLinkedPanelBaseEntriesForTool(Player player,
+                                                            String toolId,
+                                                            com.alechilles.alecstamework.config.assets.TwCommandItemConfig config) {
+        if (player == null || toolId == null || toolId.isBlank()) {
+            return List.of();
+        }
+        Inventory inventory = player.getInventory();
+        if (inventory == null || inventory.getHotbar() == null) {
+            return List.of();
+        }
+        ItemContainer hotbar = inventory.getHotbar();
+        short capacity = hotbar.getCapacity();
+        for (short slot = 0; slot < capacity; slot++) {
+            ItemStack stack = hotbar.getItemStack(slot);
+            if (stack == null || stack.isEmpty()) {
+                continue;
+            }
+            String stackToolId = stack.getFromMetadataOrNull(TameworkMetadataKeys.COMMAND_TOOL_ID, Codec.STRING);
+            if (stackToolId == null || !stackToolId.equals(toolId)) {
+                continue;
+            }
+            World world = player.getWorld();
+            if (world == null) {
+                return List.of();
+            }
+            Store<EntityStore> store = world.getEntityStore().getStore();
+            if (store == null) {
+                return List.of();
+            }
+            ItemStack unfilteredStack = panelPreferenceService.applySelectedFilterText(stack, "");
+            if (panelEntrySourceService != null) {
+                return panelEntrySourceService.buildEntries(player, store, unfilteredStack, config, toolId);
+            }
+            return panelEntryService.buildEntries(player, store, unfilteredStack, toolId);
         }
         return List.of();
     }

--- a/src/main/java/com/alechilles/alecstamework/ui/LinkedNpcEntry.java
+++ b/src/main/java/com/alechilles/alecstamework/ui/LinkedNpcEntry.java
@@ -1,6 +1,8 @@
 package com.alechilles.alecstamework.ui;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -501,6 +503,101 @@ public final class LinkedNpcEntry {
         return Math.max(0, Math.min(100, Math.round((float) (ratio * 100.0))));
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof LinkedNpcEntry other)) {
+            return false;
+        }
+        return currentHealth == other.currentHealth
+                && maxHealth == other.maxHealth
+                && currentHappiness == other.currentHappiness
+                && maxHappiness == other.maxHappiness
+                && targetHappinessPercent == other.targetHappinessPercent
+                && currentHunger == other.currentHunger
+                && maxHunger == other.maxHunger
+                && currentThirst == other.currentThirst
+                && maxThirst == other.maxThirst
+                && loaded == other.loaded
+                && linked == other.linked
+                && active == other.active
+                && dead == other.dead
+                && captured == other.captured
+                && inCoop == other.inCoop
+                && lost == other.lost
+                && hasHome == other.hasHome
+                && deadRespawnRemainingMs == other.deadRespawnRemainingMs
+                && breedingEnabled == other.breedingEnabled
+                && breedingCooldownActive == other.breedingCooldownActive
+                && breedingCooldownRemainingMs == other.breedingCooldownRemainingMs
+                && Double.compare(breedingCooldownRatio, other.breedingCooldownRatio) == 0
+                && breedingCooldownKnown == other.breedingCooldownKnown
+                && traitsActionVisible == other.traitsActionVisible
+                && traitsActionEnabled == other.traitsActionEnabled
+                && talentsActionVisible == other.talentsActionVisible
+                && talentsActionEnabled == other.talentsActionEnabled
+                && Objects.equals(npcUuid, other.npcUuid)
+                && Objects.equals(displayName, other.displayName)
+                && Objects.equals(happinessModifierBreakdown, other.happinessModifierBreakdown)
+                && Objects.equals(deathCauseHint, other.deathCauseHint)
+                && Objects.equals(speciesId, other.speciesId)
+                && Objects.equals(speciesLabel, other.speciesLabel)
+                && Objects.equals(groupId, other.groupId)
+                && Objects.equals(groupName, other.groupName)
+                && Objects.equals(groupColorHex, other.groupColorHex)
+                && Objects.equals(futureStatA, other.futureStatA)
+                && Objects.equals(futureStatB, other.futureStatB)
+                && Arrays.equals(traitIndicators, other.traitIndicators);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(
+                npcUuid,
+                displayName,
+                currentHealth,
+                maxHealth,
+                currentHappiness,
+                maxHappiness,
+                targetHappinessPercent,
+                happinessModifierBreakdown,
+                currentHunger,
+                maxHunger,
+                currentThirst,
+                maxThirst,
+                loaded,
+                linked,
+                active,
+                dead,
+                captured,
+                inCoop,
+                lost,
+                hasHome,
+                deadRespawnRemainingMs,
+                deathCauseHint,
+                speciesId,
+                speciesLabel,
+                groupId,
+                groupName,
+                groupColorHex,
+                breedingEnabled,
+                breedingCooldownActive,
+                breedingCooldownRemainingMs,
+                breedingCooldownRatio,
+                breedingCooldownKnown,
+                futureStatA,
+                futureStatB,
+                traitsActionVisible,
+                traitsActionEnabled,
+                talentsActionVisible,
+                talentsActionEnabled
+        );
+        result = 31 * result + Arrays.hashCode(traitIndicators);
+        return result;
+    }
+
     /**
      * Placeholder stat entry used for future linked-panel bars (hunger/thirst/happiness/etc.).
      */
@@ -525,6 +622,22 @@ public final class LinkedNpcEntry {
 
         public int max() {
             return max;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof FutureStat other)) {
+                return false;
+            }
+            return current == other.current && max == other.max && Objects.equals(label, other.label);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(label, current, max);
         }
     }
 }

--- a/src/main/java/com/alechilles/alecstamework/ui/LinkedNpcTraitIndicator.java
+++ b/src/main/java/com/alechilles/alecstamework/ui/LinkedNpcTraitIndicator.java
@@ -1,6 +1,7 @@
 package com.alechilles.alecstamework.ui;
 
 import com.alechilles.alecstamework.localization.LocalizedText;
+import java.util.Objects;
 
 /**
  * Immutable trait indicator model rendered in linked companion cards.
@@ -83,5 +84,27 @@ public final class LinkedNpcTraitIndicator {
             return 0.0;
         }
         return Math.max(0.0, Math.min(1.0, value));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof LinkedNpcTraitIndicator other)) {
+            return false;
+        }
+        return Double.compare(fillRatio, other.fillRatio) == 0
+                && counterClockwise == other.counterClockwise
+                && belowDefault == other.belowDefault
+                && Objects.equals(iconText, other.iconText)
+                && Objects.equals(iconTexturePath, other.iconTexturePath)
+                && Objects.equals(label, other.label)
+                && Objects.equals(tooltipText, other.tooltipText);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(iconText, iconTexturePath, label, tooltipText, fillRatio, counterClockwise, belowDefault);
     }
 }

--- a/src/main/java/com/alechilles/alecstamework/ui/TameworkCommandSelectionPage.java
+++ b/src/main/java/com/alechilles/alecstamework/ui/TameworkCommandSelectionPage.java
@@ -706,7 +706,8 @@ public final class TameworkCommandSelectionPage
         boolean hasEntries = linkedNpcEntries.length > 0;
         commandBuilder.set("#TameworkLinkedPanelEmptyState.Visible", !hasEntries);
         commandBuilder.set("#TameworkLinkedPanelListViewport.Visible", hasEntries);
-        boolean structureChanged = renderedLinkedNpcCardCount != linkedNpcEntries.length;
+        boolean structureChanged = renderedLinkedNpcCardCount != linkedNpcEntries.length
+                || renderedLinkedNpcEntries.length != linkedNpcEntries.length;
         boolean pendingUnlinkChanged = !java.util.Objects.equals(renderedPendingUnlinkNpcUuid, pendingUnlinkNpcUuid);
         if (structureChanged) {
             commandBuilder.clear("#TameworkLinkedPanelList");

--- a/src/main/java/com/alechilles/alecstamework/ui/TameworkCommandSelectionPage.java
+++ b/src/main/java/com/alechilles/alecstamework/ui/TameworkCommandSelectionPage.java
@@ -21,6 +21,7 @@ import com.hypixel.hytale.server.core.universe.world.World;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -68,6 +69,7 @@ public final class TameworkCommandSelectionPage
     private static final String PANEL_SORT_DEFAULT = "Default";
     private static final String PANEL_FILTER_NONE = "None";
     private static final int MAX_COMMAND_BUTTONS = 8;
+    private static final long PANEL_FILTER_INPUT_DEBOUNCE_MS = 500L;
     private static final long LINKED_PANEL_REFRESH_INTERVAL_MS = 1000L;
     private static final LinkedNpcPanelCardBinder.CardBindingConfig CARD_BINDING_CONFIG =
             new LinkedNpcPanelCardBinder.CardBindingConfig(
@@ -89,15 +91,19 @@ public final class TameworkCommandSelectionPage
     private final CommandOption[] options;
     private final boolean requireUnlinkConfirm;
     private final Supplier<List<LinkedNpcEntry>> linkedNpcEntriesSupplier;
+    private final Supplier<List<LinkedNpcEntry>> linkedNpcBaseEntriesSupplier;
     private final Supplier<String> panelModeValueSupplier;
     private final Supplier<String> panelRadiusLabelSupplier;
     private final Supplier<String> panelSortValueSupplier;
     private final Supplier<String> panelFilterModeValueSupplier;
     private final Supplier<String> panelFilterInputValueSupplier;
     private final Supplier<List<DropdownEntryInfo>> panelGroupAssignEntriesSupplier;
+    private LinkedNpcEntry[] baseLinkedNpcEntries;
     private LinkedNpcEntry[] linkedNpcEntries;
+    private LinkedNpcEntry[] renderedLinkedNpcEntries;
     private int renderedLinkedNpcCardCount;
     private UUID pendingUnlinkNpcUuid;
+    private UUID renderedPendingUnlinkNpcUuid;
     private final String selectedCommandId;
     private final Consumer<String> selectionCallback;
     private final Consumer<UUID> linkCallback;
@@ -127,12 +133,15 @@ public final class TameworkCommandSelectionPage
     private volatile boolean refreshLoopStarted;
     private volatile boolean dismissed;
     private volatile boolean navigationPending;
+    private volatile long pendingFilterTextApplyVersion;
+    private String pendingFilterTextInput;
 
     public TameworkCommandSelectionPage(@Nonnull PlayerRef playerRef,
                                         @Nonnull TwCommandItemConfig config,
                                         String selectedCommandId,
                                         boolean requireUnlinkConfirm,
                                         @Nonnull Supplier<List<LinkedNpcEntry>> linkedNpcEntriesSupplier,
+                                        @Nonnull Supplier<List<LinkedNpcEntry>> linkedNpcBaseEntriesSupplier,
                                         @Nonnull Supplier<String> panelModeValueSupplier,
                                         @Nonnull Supplier<String> panelRadiusLabelSupplier,
                                         @Nonnull Supplier<String> panelSortValueSupplier,
@@ -163,15 +172,19 @@ public final class TameworkCommandSelectionPage
         this.options = buildOptions(config);
         this.requireUnlinkConfirm = requireUnlinkConfirm;
         this.linkedNpcEntriesSupplier = linkedNpcEntriesSupplier;
+        this.linkedNpcBaseEntriesSupplier = linkedNpcBaseEntriesSupplier;
         this.panelModeValueSupplier = panelModeValueSupplier;
         this.panelRadiusLabelSupplier = panelRadiusLabelSupplier;
         this.panelSortValueSupplier = panelSortValueSupplier;
         this.panelFilterModeValueSupplier = panelFilterModeValueSupplier;
         this.panelFilterInputValueSupplier = panelFilterInputValueSupplier;
         this.panelGroupAssignEntriesSupplier = panelGroupAssignEntriesSupplier;
+        this.baseLinkedNpcEntries = new LinkedNpcEntry[0];
         this.linkedNpcEntries = new LinkedNpcEntry[0];
+        this.renderedLinkedNpcEntries = new LinkedNpcEntry[0];
         this.renderedLinkedNpcCardCount = 0;
         this.pendingUnlinkNpcUuid = null;
+        this.renderedPendingUnlinkNpcUuid = null;
         this.selectedCommandId = selectedCommandId;
         this.linkCallback = linkCallback;
         this.unlinkCallback = unlinkCallback;
@@ -204,6 +217,8 @@ public final class TameworkCommandSelectionPage
         this.refreshLoopStarted = false;
         this.dismissed = false;
         this.navigationPending = false;
+        this.pendingFilterTextApplyVersion = 0L;
+        this.pendingFilterTextInput = null;
     }
 
     @Override
@@ -283,6 +298,7 @@ public final class TameworkCommandSelectionPage
             return;
         }
         if (data.panelModeValue != null) {
+            cancelPendingFilterTextApply();
             if (panelSetModeCallback != null) {
                 panelSetModeCallback.accept(data.panelModeValue);
             }
@@ -292,6 +308,7 @@ public final class TameworkCommandSelectionPage
             return;
         }
         if (data.panelSortValue != null) {
+            cancelPendingFilterTextApply();
             if (panelSetSortCallback != null) {
                 panelSetSortCallback.accept(data.panelSortValue);
             }
@@ -301,6 +318,7 @@ public final class TameworkCommandSelectionPage
             return;
         }
         if (data.panelFilterModeValue != null) {
+            cancelPendingFilterTextApply();
             if (panelSetFilterModeCallback != null) {
                 panelSetFilterModeCallback.accept(data.panelFilterModeValue);
             }
@@ -310,12 +328,8 @@ public final class TameworkCommandSelectionPage
             return;
         }
         if (data.panelFilterTextInput != null) {
-            if (panelSetFilterTextCallback != null) {
-                panelSetFilterTextCallback.accept(data.panelFilterTextInput);
-            }
-            pendingUnlinkNpcUuid = null;
-            refreshLinkedNpcEntries();
-            sendCardRefreshUpdate();
+            pendingFilterTextInput = data.panelFilterTextInput;
+            scheduleDebouncedFilterTextApply();
             return;
         }
         if (commandId.isBlank()) {
@@ -362,6 +376,7 @@ public final class TameworkCommandSelectionPage
             return;
         }
         if (PANEL_FILTER_CLEAR_COMMAND_ID.equals(commandId)) {
+            cancelPendingFilterTextApply();
             if (panelClearFiltersCallback != null) {
                 panelClearFiltersCallback.run();
                 pendingUnlinkNpcUuid = null;
@@ -601,8 +616,59 @@ public final class TameworkCommandSelectionPage
         world.execute(this::runRefreshTickOnWorldThread);
     }
 
+    private void scheduleDebouncedFilterTextApply() {
+        long version = ++pendingFilterTextApplyVersion;
+        CompletableFuture.runAsync(
+                () -> dispatchDebouncedFilterTextApply(version),
+                CompletableFuture.delayedExecutor(PANEL_FILTER_INPUT_DEBOUNCE_MS, TimeUnit.MILLISECONDS)
+        );
+    }
+
+    private void dispatchDebouncedFilterTextApply(long version) {
+        if (dismissed || version != pendingFilterTextApplyVersion) {
+            return;
+        }
+        Ref<EntityStore> ref = playerRef.getReference();
+        if (ref == null || !ref.isValid()) {
+            return;
+        }
+        Store<EntityStore> store = ref.getStore();
+        if (store == null || store.getExternalData() == null) {
+            return;
+        }
+        World world = store.getExternalData().getWorld();
+        if (world == null) {
+            return;
+        }
+        world.execute(() -> runDebouncedFilterTextApplyOnWorldThread(version));
+    }
+
+    private void runDebouncedFilterTextApplyOnWorldThread(long version) {
+        if (dismissed || version != pendingFilterTextApplyVersion) {
+            return;
+        }
+        if (panelSetFilterTextCallback != null) {
+            panelSetFilterTextCallback.accept(pendingFilterTextInput);
+        }
+        pendingFilterTextInput = null;
+        pendingUnlinkNpcUuid = null;
+        applyLocalFilterToLinkedNpcEntries();
+        sendCardRefreshUpdate();
+    }
+
+    private void cancelPendingFilterTextApply() {
+        pendingFilterTextApplyVersion++;
+        pendingFilterTextInput = null;
+    }
+
     private void runRefreshTickOnWorldThread() {
         if (dismissed) {
+            return;
+        }
+        if (isFilterEditPending()) {
+            if (!dismissed) {
+                scheduleRefreshTick();
+            }
             return;
         }
         refreshLinkedNpcEntries();
@@ -633,12 +699,15 @@ public final class TameworkCommandSelectionPage
         commandBuilder.set("#TameworkLinkedPanelFilterDropdown.Value", resolvePanelFilterModeValue());
         boolean showFilterInputControls = shouldShowFilterInputControls();
         commandBuilder.set("#TameworkLinkedPanelInlineFilterTextControls.Visible", showFilterInputControls);
-        commandBuilder.set("#TameworkLinkedPanelFilterInput.Value", resolvePanelFilterInputValue());
+        if (!isFilterEditPending()) {
+            commandBuilder.set("#TameworkLinkedPanelFilterInput.Value", resolveAppliedPanelFilterInputValue());
+        }
         applyGroupAssignOverlayState(commandBuilder);
         boolean hasEntries = linkedNpcEntries.length > 0;
         commandBuilder.set("#TameworkLinkedPanelEmptyState.Visible", !hasEntries);
         commandBuilder.set("#TameworkLinkedPanelListViewport.Visible", hasEntries);
         boolean structureChanged = renderedLinkedNpcCardCount != linkedNpcEntries.length;
+        boolean pendingUnlinkChanged = !java.util.Objects.equals(renderedPendingUnlinkNpcUuid, pendingUnlinkNpcUuid);
         if (structureChanged) {
             commandBuilder.clear("#TameworkLinkedPanelList");
             renderedLinkedNpcCardCount = linkedNpcEntries.length;
@@ -649,13 +718,29 @@ public final class TameworkCommandSelectionPage
             }
         } else if (hasEntries) {
             for (int i = 0; i < linkedNpcEntries.length; i++) {
-                bindLinkedNpcCard(commandBuilder, eventBuilder, i, linkedNpcEntries[i], false);
+                boolean wasPendingUnlink = isPendingUnlink(renderedLinkedNpcEntries, renderedPendingUnlinkNpcUuid, i);
+                boolean isPendingUnlink = isPendingUnlink(linkedNpcEntries, pendingUnlinkNpcUuid, i);
+                if (!java.util.Objects.equals(linkedNpcEntries[i], renderedLinkedNpcEntries[i])
+                        || wasPendingUnlink != isPendingUnlink
+                        || pendingUnlinkChanged) {
+                    bindLinkedNpcCard(commandBuilder, eventBuilder, i, linkedNpcEntries[i], false);
+                }
             }
         }
+        renderedLinkedNpcEntries = linkedNpcEntries.clone();
+        renderedPendingUnlinkNpcUuid = pendingUnlinkNpcUuid;
         bindCommandButtonEvents(eventBuilder);
         bindPanelControlEvents(eventBuilder);
         bindCloseButtonEvent(eventBuilder);
         sendUpdate(commandBuilder, eventBuilder, false);
+    }
+
+    private boolean isPendingUnlink(LinkedNpcEntry[] entries, UUID pendingUuid, int index) {
+        if (entries == null || pendingUuid == null || index < 0 || index >= entries.length) {
+            return false;
+        }
+        LinkedNpcEntry entry = entries[index];
+        return entry != null && pendingUuid.equals(entry.npcUuid());
     }
 
     private void closePage() {
@@ -909,15 +994,71 @@ public final class TameworkCommandSelectionPage
     }
 
     private void refreshLinkedNpcEntries() {
-        List<LinkedNpcEntry> entries = linkedNpcEntriesSupplier != null ? linkedNpcEntriesSupplier.get() : List.of();
-        linkedNpcEntries = LinkedNpcEntrySnapshotMapper.build(
+        List<LinkedNpcEntry> entries = linkedNpcBaseEntriesSupplier != null
+                ? linkedNpcBaseEntriesSupplier.get()
+                : linkedNpcEntriesSupplier != null
+                ? linkedNpcEntriesSupplier.get()
+                : List.of();
+        baseLinkedNpcEntries = LinkedNpcEntrySnapshotMapper.build(
                 entries,
                 LocalizedText.resolve(resolveLanguage(), "tamework.ui.linkedPanel.subtitle.defaultNpcName")
         );
+        applyLocalFilterToLinkedNpcEntries();
         if (pendingUnlinkNpcUuid != null
                 && !LinkedNpcPanelSubtitleService.containsEntry(linkedNpcEntries, pendingUnlinkNpcUuid)) {
             pendingUnlinkNpcUuid = null;
         }
+    }
+
+    private void applyLocalFilterToLinkedNpcEntries() {
+        LinkedNpcEntry[] source = baseLinkedNpcEntries != null ? baseLinkedNpcEntries : new LinkedNpcEntry[0];
+        if (source.length == 0) {
+            linkedNpcEntries = source;
+            return;
+        }
+        String filterMode = resolvePanelFilterModeValue();
+        String filterText = resolveAppliedPanelFilterInputValue();
+        if (filterMode == null || filterMode.isBlank() || PANEL_FILTER_NONE.equalsIgnoreCase(filterMode)
+                || filterText == null || filterText.isBlank()) {
+            linkedNpcEntries = source;
+            return;
+        }
+        String normalizedFilter = filterText.trim().toLowerCase(Locale.ROOT);
+        ArrayList<LinkedNpcEntry> filtered = new ArrayList<>(source.length);
+        for (LinkedNpcEntry entry : source) {
+            if (entry == null) {
+                continue;
+            }
+            if (matchesLocalFilter(entry, filterMode, normalizedFilter)) {
+                filtered.add(entry);
+            }
+        }
+        linkedNpcEntries = filtered.toArray(new LinkedNpcEntry[0]);
+    }
+
+    private boolean matchesLocalFilter(@Nonnull LinkedNpcEntry entry,
+                                       @Nonnull String filterMode,
+                                       @Nonnull String normalizedFilter) {
+        String candidate = switch (filterMode.trim().toLowerCase(Locale.ROOT)) {
+            case "name" -> entry.displayName();
+            case "species" -> firstNonBlank(entry.speciesLabel(), entry.speciesId());
+            case "group" -> firstNonBlank(entry.groupName(), entry.groupId());
+            default -> null;
+        };
+        if (candidate == null || candidate.isBlank()) {
+            return false;
+        }
+        return candidate.toLowerCase(Locale.ROOT).contains(normalizedFilter);
+    }
+
+    private String firstNonBlank(String first, String second) {
+        if (first != null && !first.isBlank()) {
+            return first;
+        }
+        if (second != null && !second.isBlank()) {
+            return second;
+        }
+        return "";
     }
 
     private boolean containsOption(String commandId) {
@@ -993,6 +1134,17 @@ public final class TameworkCommandSelectionPage
     }
 
     private String resolvePanelFilterInputValue() {
+        if (pendingFilterTextInput != null) {
+            return pendingFilterTextInput;
+        }
+        return resolveAppliedPanelFilterInputValue();
+    }
+
+    private boolean isFilterEditPending() {
+        return pendingFilterTextInput != null;
+    }
+
+    private String resolveAppliedPanelFilterInputValue() {
         if (panelFilterInputValueSupplier == null) {
             return "";
         }

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -18,7 +18,8 @@
     "OptionalDependencies": {
         "org.herolias:DynamicTooltipsLib": "1.5.x",
         "Frotty27:NameplateBuilder": ">=4.260326.7",
-        "Buuz135:SimpleClaims": "1.0.x"
+        "Buuz135:SimpleClaims": "1.0.x",
+        "Alechilles:Alec's Telemetry": ">=0.1.0"
     },
     "LoadBefore": {},
     "DisabledByDefault": false,

--- a/src/main/resources/telemetry/project.json
+++ b/src/main/resources/telemetry/project.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "projectId": "alecs-tamework",
+  "displayName": "Alec's Tamework!",
+  "ownerPluginIdentifiers": [
+    "Alechilles:Alec's Tamework!"
+  ],
+  "packagePrefixes": [
+    "com.alechilles.alecstamework"
+  ],
+  "capture": {
+    "uncaughtExceptions": true,
+    "setupFailures": true,
+    "startFailures": true,
+    "exceptionalWorldRemovals": true
+  },
+  "defaults": {
+    "enabled": true,
+    "destinationMode": "hosted"
+  },
+  "hosted": {
+    "endpoint": "http://127.0.0.1:8787/api/v1/ingest/crash",
+    "projectKey": "dev_tamework_local_test"
+  }
+}


### PR DESCRIPTION
## Summary
- add optional Alec's Telemetry integration hooks and a packaged telemetry project descriptor for Tamework
- update the command panel / linked NPC UI and command inventory flows that were already pending in the repo
- wire Tamework to expose the new telemetry dependency path without removing the legacy crash service yet

## Validation
- ./mvnw.cmd test