### PR TITLE
Point telemetry descriptor to public hosted endpoint

### DIFF
--- a/src/main/resources/telemetry/project.json
+++ b/src/main/resources/telemetry/project.json
@@ -19,7 +19,7 @@
     "destinationMode": "hosted"
   },
   "hosted": {
-    "endpoint": "http://127.0.0.1:8787/api/v1/ingest/crash",
+    "endpoint": "https://telemetry.alecsmods.com/ingest/crash",
     "projectKey": "dev_tamework_local_test"
   }
 }


### PR DESCRIPTION
## Summary
- update Tamework's packaged telemetry descriptor to point at the public hosted telemetry endpoint
- keep the dev project key unchanged while aligning the packaged descriptor with the canonical production host

## Validation
- descriptor-only change