### PR TITLE
Feat: emit live Alec's Telemetry events

### DIFF
--- a/src/main/java/com/alechilles/alecstamework/Tamework.java
+++ b/src/main/java/com/alechilles/alecstamework/Tamework.java
@@ -73,6 +73,7 @@ import com.alechilles.alecstamework.items.TranquilizerRecipeVisibilityService;
 import com.alechilles.alecstamework.localization.ModLanguageDiscovery;
 import com.alechilles.alecstamework.localization.TranslationRegistry;
 import com.alechilles.alecstamework.metrics.CrashTelemetryService;
+import com.alechilles.alecstamework.metrics.TameworkTelemetryEvents;
 import com.alechilles.alecstamework.metrics.TameworkHStatsIntegration;
 import com.alechilles.alecstamework.npc.TameworkNpcBuilderRegistrar;
 import com.alechilles.alecstamework.npc.components.TameworkAttachmentsComponent;
@@ -187,6 +188,7 @@ public class Tamework extends JavaPlugin {
     private TameworkNpcBuilderRegistrar npcBuilderRegistrar;
     private TameworkHStatsIntegration hStatsIntegration;
     private CrashTelemetryService crashTelemetryService;
+    private final TameworkTelemetryEvents telemetryEvents = new TameworkTelemetryEvents();
     private TameworkSettingsAnnouncementService settingsAnnouncementService;
     private SpawnerTooltipBridge spawnerTooltipBridge;
     private boolean globalAssetsRegistered;
@@ -247,10 +249,18 @@ public class Tamework extends JavaPlugin {
 
     @Override
     protected void setup() {
+        long startedAtNanos = System.nanoTime();
         initializeCrashTelemetry();
         try {
             setupInternal();
+            int durationMs = telemetryEvents.elapsedMillis(startedAtNanos);
+            telemetryEvents.recordLifecycle("plugin_setup", durationMs, true, "Tamework setupInternal completed.");
+            telemetryEvents.recordPerformance("plugin_setup_duration", durationMs, (double) durationMs, "Tamework plugin setup duration.");
         } catch (Throwable throwable) {
+            int durationMs = telemetryEvents.elapsedMillis(startedAtNanos);
+            telemetryEvents.recordLifecycle("plugin_setup", durationMs, false, "Tamework setupInternal failed.");
+            telemetryEvents.recordPerformance("plugin_setup_duration", durationMs, (double) durationMs, "Failed Tamework plugin setup duration.");
+            telemetryEvents.recordError("plugin_setup_failed", throwable, "Tamework setupInternal threw an exception.");
             captureSetupFailure(throwable);
             throw throwable;
         }
@@ -715,9 +725,17 @@ public class Tamework extends JavaPlugin {
 
     @Override
     protected void start() {
+        long startedAtNanos = System.nanoTime();
         try {
             startInternal();
+            int durationMs = telemetryEvents.elapsedMillis(startedAtNanos);
+            telemetryEvents.recordLifecycle("plugin_start", durationMs, true, "Tamework startInternal completed.");
+            telemetryEvents.recordPerformance("plugin_start_duration", durationMs, (double) durationMs, "Tamework plugin start duration.");
         } catch (Throwable throwable) {
+            int durationMs = telemetryEvents.elapsedMillis(startedAtNanos);
+            telemetryEvents.recordLifecycle("plugin_start", durationMs, false, "Tamework startInternal failed.");
+            telemetryEvents.recordPerformance("plugin_start_duration", durationMs, (double) durationMs, "Failed Tamework plugin start duration.");
+            telemetryEvents.recordError("plugin_start_failed", throwable, "Tamework startInternal threw an exception.");
             captureStartFailure(throwable);
             throw throwable;
         }
@@ -836,6 +854,15 @@ public class Tamework extends JavaPlugin {
         }
         TwConfigOverrideManager.ReloadResult reloadResult = configOverrideManager.reloadOverrides(world);
         if (reloadResult.hasErrors()) {
+            telemetryEvents.recordError(
+                    "world_override_reload_errors",
+                    null,
+                    "Loaded overrides for world "
+                            + world.getName()
+                            + " with "
+                            + reloadResult.getErrors().size()
+                            + " error(s)."
+            );
             getLogger().at(Level.WARNING).log(
                     "Loaded Tamework overrides for world "
                             + world.getName()
@@ -888,6 +915,11 @@ public class Tamework extends JavaPlugin {
     @Nullable
     public CrashTelemetryService getCrashTelemetryService() {
         return crashTelemetryService;
+    }
+
+    @Nonnull
+    public TameworkTelemetryEvents getTelemetryEvents() {
+        return telemetryEvents;
     }
 
     @Nullable

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkDebugCrashTelemetryCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkDebugCrashTelemetryCommand.java
@@ -1,6 +1,7 @@
 package com.alechilles.alecstamework.commands;
 
 import com.alechilles.alecstamework.Tamework;
+import com.alechilles.alecstamework.metrics.AlecsTelemetryBridge;
 import com.alechilles.alecstamework.metrics.CrashTelemetryDiagnostics;
 import com.alechilles.alecstamework.metrics.CrashTelemetryService;
 import com.hypixel.hytale.server.core.HytaleServer;
@@ -31,7 +32,7 @@ public final class TameworkDebugCrashTelemetryCommand extends AbstractPlayerComm
     );
 
     public TameworkDebugCrashTelemetryCommand() {
-        super("debugcrashtelemetry", "Show crash telemetry diagnostics. Optional: flush|simulate");
+        super("debugcrashtelemetry", "Show crash telemetry diagnostics. Optional: flush|simulate|eventerror|eventlifecycle");
         setAllowsExtraArguments(true);
     }
 
@@ -61,6 +62,23 @@ public final class TameworkDebugCrashTelemetryCommand extends AbstractPlayerComm
                             ? "Crash telemetry flush scheduled."
                             : "Crash telemetry flush was not scheduled (disabled, already running, or no executor available)."
             ));
+        } else if ("eventerror".equals(action)) {
+            String token = Long.toHexString(System.currentTimeMillis());
+            AlecsTelemetryBridge.InvocationResult result = new AlecsTelemetryBridge().recordError(
+                    "debug_command_error",
+                    new IllegalStateException("Simulated Tamework telemetry error event (" + token + ")"),
+                    "Triggered by /tw debugcrashtelemetry eventerror (token=" + token + ")"
+            );
+            commandContext.sender().sendMessage(Message.raw(result.message()));
+        } else if ("eventlifecycle".equals(action)) {
+            String token = Long.toHexString(System.currentTimeMillis());
+            AlecsTelemetryBridge.InvocationResult result = new AlecsTelemetryBridge().recordLifecycle(
+                    "debug_command_lifecycle",
+                    123,
+                    true,
+                    "Triggered by /tw debugcrashtelemetry eventlifecycle (token=" + token + ")"
+            );
+            commandContext.sender().sendMessage(Message.raw(result.message()));
         } else if ("simulate".equals(action)) {
             Player player = store.getComponent(ref, Player.getComponentType());
             UUID playerUuid = player == null ? null : player.getUuid();
@@ -88,7 +106,7 @@ public final class TameworkDebugCrashTelemetryCommand extends AbstractPlayerComm
                 }
             }
         } else if (action != null) {
-            commandContext.sender().sendMessage(Message.raw("Usage: /tw debugcrashtelemetry [flush|simulate]"));
+            commandContext.sender().sendMessage(Message.raw("Usage: /tw debugcrashtelemetry [flush|simulate|eventerror|eventlifecycle]"));
             return;
         }
 

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkDebugCrashTelemetryCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkDebugCrashTelemetryCommand.java
@@ -63,6 +63,14 @@ public final class TameworkDebugCrashTelemetryCommand extends AbstractPlayerComm
                             : "Crash telemetry flush was not scheduled (disabled, already running, or no executor available)."
             ));
         } else if ("eventerror".equals(action)) {
+            Player player = store.getComponent(ref, Player.getComponentType());
+            UUID playerUuid = player == null ? null : player.getUuid();
+            if (!isAllowedSimulateCaller(playerUuid)) {
+                commandContext.sender().sendMessage(Message.raw(
+                        "You are not allowed to run /tw debugcrashtelemetry eventerror."
+                ));
+                return;
+            }
             String token = Long.toHexString(System.currentTimeMillis());
             AlecsTelemetryBridge.InvocationResult result = new AlecsTelemetryBridge().recordError(
                     "debug_command_error",
@@ -71,6 +79,14 @@ public final class TameworkDebugCrashTelemetryCommand extends AbstractPlayerComm
             );
             commandContext.sender().sendMessage(Message.raw(result.message()));
         } else if ("eventlifecycle".equals(action)) {
+            Player player = store.getComponent(ref, Player.getComponentType());
+            UUID playerUuid = player == null ? null : player.getUuid();
+            if (!isAllowedSimulateCaller(playerUuid)) {
+                commandContext.sender().sendMessage(Message.raw(
+                        "You are not allowed to run /tw debugcrashtelemetry eventlifecycle."
+                ));
+                return;
+            }
             String token = Long.toHexString(System.currentTimeMillis());
             AlecsTelemetryBridge.InvocationResult result = new AlecsTelemetryBridge().recordLifecycle(
                     "debug_command_lifecycle",

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkReloadConfigCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkReloadConfigCommand.java
@@ -2,6 +2,7 @@ package com.alechilles.alecstamework.commands;
 
 import com.alechilles.alecstamework.Tamework;
 import com.alechilles.alecstamework.config.overrides.TwConfigOverrideManager;
+import com.alechilles.alecstamework.metrics.TameworkTelemetryEvents;
 import com.alechilles.alecstamework.persistence.TameworkSettingsStore;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
@@ -36,6 +37,9 @@ public final class TameworkReloadConfigCommand extends AbstractPlayerCommand {
             commandContext.sender().sendMessage(Message.raw("Tamework plugin not available."));
             return;
         }
+        TameworkTelemetryEvents telemetryEvents = plugin.getTelemetryEvents();
+        long startedAtNanos = System.nanoTime();
+        telemetryEvents.recordUsage("reload_config_command_used", "Triggered by /tw reloadconfig.");
         commandContext.sender().sendMessage(Message.raw("Reloading Tamework configs..."));
         CompletableFuture.supplyAsync(() -> {
             TameworkSettingsStore.invalidateRuntimeGlobalOverridesCache();
@@ -49,12 +53,25 @@ public final class TameworkReloadConfigCommand extends AbstractPlayerCommand {
                     : 0;
             return new ReloadSummary(reloadResult, loaded, totalSpawners, totalNaming);
         }).whenComplete((summary, throwable) -> world.execute(() -> {
+            int durationMs = telemetryEvents.elapsedMillis(startedAtNanos);
             if (throwable != null || summary == null) {
                 plugin.getLogger().at(Level.WARNING).withCause(throwable).log("Async /tw reloadconfig failed.");
+                telemetryEvents.recordLifecycle("reload_config", durationMs, false, "Async /tw reloadconfig failed.");
+                telemetryEvents.recordPerformance("reload_config_duration", durationMs, (double) durationMs, "Failed /tw reloadconfig duration.");
+                telemetryEvents.recordError("reload_config_failed", throwable, "Async /tw reloadconfig failed.");
                 commandContext.sender().sendMessage(Message.raw("Reload failed. See server log for details."));
                 return;
             }
             plugin.applyDebugConfigDefaults();
+            telemetryEvents.recordLifecycle("reload_config", durationMs, true, "Reloaded Tamework configs via /tw reloadconfig.");
+            telemetryEvents.recordPerformance("reload_config_duration", durationMs, (double) durationMs, "Successful /tw reloadconfig duration.");
+            if (summary.reloadResult().hasErrors()) {
+                telemetryEvents.recordError(
+                        "reload_config_override_errors",
+                        null,
+                        "Reloaded with " + summary.reloadResult().getErrors().size() + " override error(s)."
+                );
+            }
             commandContext.sender().sendMessage(Message.raw(
                     "Reloaded Tamework configs. OverridePacks=" + summary.reloadResult().getLoadedPacks()
                             + " OverrideDirs=" + summary.reloadResult().getLoadedDirectories()

--- a/src/main/java/com/alechilles/alecstamework/metrics/AlecsTelemetryBridge.java
+++ b/src/main/java/com/alechilles/alecstamework/metrics/AlecsTelemetryBridge.java
@@ -1,0 +1,110 @@
+package com.alechilles.alecstamework.metrics;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.reflect.Method;
+
+/**
+ * Optional reflection-based bridge to Alec's Telemetry dependency mode runtime API.
+ */
+public final class AlecsTelemetryBridge {
+
+    private static final String PROJECT_ID = "alecs-tamework";
+    private static final String LOCATOR_CLASS = "com.alechilles.alecstelemetry.api.TelemetryRuntimeLocator";
+
+    @Nonnull
+    public InvocationResult recordError(@Nonnull String eventName,
+                                        @Nullable Throwable throwable,
+                                        @Nullable String detail) {
+        try {
+            Object projectHandle = resolveProjectHandle();
+            if (projectHandle == null) {
+                return new InvocationResult(false, false, false, "Alec's Telemetry project '" + PROJECT_ID + "' is not available.");
+            }
+            Method method = projectHandle.getClass().getMethod("recordError", String.class, Throwable.class, String.class);
+            method.invoke(projectHandle, eventName, throwable, detail);
+            requestFlush(projectHandle);
+            return new InvocationResult(true, true, true, "Telemetry error event queued for project '" + PROJECT_ID + "'.");
+        } catch (ReflectiveOperationException ex) {
+            return new InvocationResult(true, true, false, "Failed to invoke Alec's Telemetry error API: " + ex.getClass().getSimpleName());
+        }
+    }
+
+    @Nonnull
+    public InvocationResult recordLifecycle(@Nonnull String eventName,
+                                            int durationMs,
+                                            boolean success,
+                                            @Nullable String detail) {
+        try {
+            Object projectHandle = resolveProjectHandle();
+            if (projectHandle == null) {
+                return new InvocationResult(false, false, false, "Alec's Telemetry project '" + PROJECT_ID + "' is not available.");
+            }
+            Method method = projectHandle.getClass().getMethod("recordLifecycle", String.class, int.class, boolean.class, String.class);
+            method.invoke(projectHandle, eventName, Math.max(0, durationMs), success, detail);
+            requestFlush(projectHandle);
+            return new InvocationResult(true, true, true, "Telemetry lifecycle event queued for project '" + PROJECT_ID + "'.");
+        } catch (ReflectiveOperationException ex) {
+            return new InvocationResult(true, true, false, "Failed to invoke Alec's Telemetry lifecycle API: " + ex.getClass().getSimpleName());
+        }
+    }
+
+    @Nonnull
+    public InvocationResult recordPerformance(@Nonnull String eventName,
+                                              int durationMs,
+                                              @Nullable Double metricValue,
+                                              @Nullable String detail) {
+        try {
+            Object projectHandle = resolveProjectHandle();
+            if (projectHandle == null) {
+                return new InvocationResult(false, false, false, "Alec's Telemetry project '" + PROJECT_ID + "' is not available.");
+            }
+            Method method = projectHandle.getClass().getMethod("recordPerformance", String.class, int.class, Double.class, String.class);
+            method.invoke(projectHandle, eventName, Math.max(0, durationMs), metricValue, detail);
+            requestFlush(projectHandle);
+            return new InvocationResult(true, true, true, "Telemetry performance event queued for project '" + PROJECT_ID + "'.");
+        } catch (ReflectiveOperationException ex) {
+            return new InvocationResult(true, true, false, "Failed to invoke Alec's Telemetry performance API: " + ex.getClass().getSimpleName());
+        }
+    }
+
+    @Nonnull
+    public InvocationResult recordUsage(@Nonnull String eventName,
+                                        @Nullable String detail) {
+        try {
+            Object projectHandle = resolveProjectHandle();
+            if (projectHandle == null) {
+                return new InvocationResult(false, false, false, "Alec's Telemetry project '" + PROJECT_ID + "' is not available.");
+            }
+            Method method = projectHandle.getClass().getMethod("recordUsage", String.class, String.class);
+            method.invoke(projectHandle, eventName, detail);
+            requestFlush(projectHandle);
+            return new InvocationResult(true, true, true, "Telemetry usage event queued for project '" + PROJECT_ID + "'.");
+        } catch (ReflectiveOperationException ex) {
+            return new InvocationResult(true, true, false, "Failed to invoke Alec's Telemetry usage API: " + ex.getClass().getSimpleName());
+        }
+    }
+
+    @Nullable
+    private Object resolveProjectHandle() throws ReflectiveOperationException {
+        Class<?> locatorClass = Class.forName(LOCATOR_CLASS);
+        Method tryGet = locatorClass.getMethod("tryGet");
+        Object api = tryGet.invoke(null);
+        if (api == null) {
+            return null;
+        }
+        Method findProject = api.getClass().getMethod("findProject", String.class);
+        return findProject.invoke(api, PROJECT_ID);
+    }
+
+    private void requestFlush(@Nonnull Object projectHandle) throws ReflectiveOperationException {
+        Method requestFlush = projectHandle.getClass().getMethod("requestFlush");
+        requestFlush.invoke(projectHandle);
+    }
+
+    public record InvocationResult(boolean runtimeAvailable,
+                                   boolean projectRegistered,
+                                   boolean invoked,
+                                   @Nonnull String message) {
+    }
+}

--- a/src/main/java/com/alechilles/alecstamework/metrics/TameworkTelemetryEvents.java
+++ b/src/main/java/com/alechilles/alecstamework/metrics/TameworkTelemetryEvents.java
@@ -1,0 +1,46 @@
+package com.alechilles.alecstamework.metrics;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Small orchestration wrapper for Alec's Telemetry event emission from live Tamework flows.
+ */
+public final class TameworkTelemetryEvents {
+
+    private final AlecsTelemetryBridge bridge = new AlecsTelemetryBridge();
+
+    public void recordError(@Nonnull String eventName,
+                            @Nullable Throwable throwable,
+                            @Nullable String detail) {
+        bridge.recordError(eventName, throwable, detail);
+    }
+
+    public void recordLifecycle(@Nonnull String eventName,
+                                int durationMs,
+                                boolean success,
+                                @Nullable String detail) {
+        bridge.recordLifecycle(eventName, durationMs, success, detail);
+    }
+
+    public void recordPerformance(@Nonnull String eventName,
+                                  int durationMs,
+                                  @Nullable Double metricValue,
+                                  @Nullable String detail) {
+        bridge.recordPerformance(eventName, durationMs, metricValue, detail);
+    }
+
+    public void recordUsage(@Nonnull String eventName,
+                            @Nullable String detail) {
+        bridge.recordUsage(eventName, detail);
+    }
+
+    public int elapsedMillis(long startedAtNanos) {
+        long elapsedNanos = System.nanoTime() - startedAtNanos;
+        if (elapsedNanos <= 0L) {
+            return 0;
+        }
+        long elapsedMs = elapsedNanos / 1_000_000L;
+        return elapsedMs > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) elapsedMs;
+    }
+}

--- a/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsPageService.java
+++ b/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsPageService.java
@@ -103,6 +103,7 @@ public final class TameworkSettingsPageService {
         }
         TameworkSettingsPage page = new TameworkSettingsPage(uiPlayerRef, plugin, world);
         player.getPageManager().openCustomPage(ref, store, page);
+        plugin.getTelemetryEvents().recordUsage("settings_page_opened", "Opened via /tw settings.");
         return null;
     }
 

--- a/src/main/resources/telemetry/project.json
+++ b/src/main/resources/telemetry/project.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "projectId": "alecs-tamework",
+  "displayName": "Alec's Tamework!",
+  "runtimeMode": "dependency",
+  "performance": {
+    "enabled": true,
+    "sampleRate": 1.0,
+    "thresholdMs": 100
+  },
+  "usage": {
+    "enabled": true,
+    "allowedEvents": [
+      "reload_config_command_used",
+      "settings_page_opened"
+    ]
+  },
+  "defaults": {
+    "destinationMode": "hosted"
+  },
+  "hosted": {}
+}


### PR DESCRIPTION
## Summary
- integrate Alec's Telemetry runtime events into live Tamework startup, settings, reload, and handled-error flows
- add optional telemetry bridge helpers plus dependency-mode project descriptor defaults for performance and usage events
- keep debug telemetry commands available while adding real non-debug event emission paths

## Validation
- .\mvnw test