### PR TITLE
Feat: bake hosted telemetry key into Tamework

### DIFF
--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkNewsCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkNewsCommand.java
@@ -61,7 +61,10 @@ public final class TameworkNewsCommand extends AbstractPlayerCommand {
 
         String error = service.openAnnouncementNow(ref, store, player);
         if (error != null) {
+            plugin.getTelemetryEvents().recordError("news_command_open_failed", null, error);
             commandContext.sender().sendMessage(Message.raw(error));
+            return;
         }
+        plugin.getTelemetryEvents().recordUsage("news_command_opened", "Opened via /tw news.");
     }
 }

--- a/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsAnnouncementService.java
+++ b/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsAnnouncementService.java
@@ -119,6 +119,7 @@ public final class TameworkSettingsAnnouncementService {
                 suppress -> onDismissAnnouncement(playerUuid, announcement.announcementId(), suppress)
         );
         player.getPageManager().openCustomPage(playerRef, store, page);
+        plugin.getTelemetryEvents().recordUsage("settings_announcement_opened", "Opened Tamework settings announcement.");
         return null;
     }
 
@@ -179,8 +180,10 @@ public final class TameworkSettingsAnnouncementService {
                                   @Nonnull String announcementId,
                                   boolean suppressUntilNextAnnouncement) {
         persistOptOutIfRequested(playerUuid, announcementId, suppressUntilNextAnnouncement);
+        plugin.getTelemetryEvents().recordUsage("settings_announcement_reviewed", "Opened settings from announcement.");
         String error = TameworkSettingsPageService.openSettingsPage(ref, store);
         if (error != null) {
+            plugin.getTelemetryEvents().recordError("settings_announcement_review_failed", null, error);
             playerRef.sendMessage(Message.raw(error));
         }
     }
@@ -199,6 +202,11 @@ public final class TameworkSettingsAnnouncementService {
         )) {
             return;
         }
+        plugin.getTelemetryEvents().recordError(
+                "settings_announcement_opt_out_persist_failed",
+                null,
+                "Failed to persist announcement opt-out for player " + playerUuid + "."
+        );
         plugin.getLogger().at(Level.WARNING).log(
                 "Failed to persist Tamework settings announcement opt-out for player " + playerUuid + "."
         );

--- a/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsAnnouncementService.java
+++ b/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsAnnouncementService.java
@@ -180,12 +180,13 @@ public final class TameworkSettingsAnnouncementService {
                                   @Nonnull String announcementId,
                                   boolean suppressUntilNextAnnouncement) {
         persistOptOutIfRequested(playerUuid, announcementId, suppressUntilNextAnnouncement);
-        plugin.getTelemetryEvents().recordUsage("settings_announcement_reviewed", "Opened settings from announcement.");
         String error = TameworkSettingsPageService.openSettingsPage(ref, store);
         if (error != null) {
             plugin.getTelemetryEvents().recordError("settings_announcement_review_failed", null, error);
             playerRef.sendMessage(Message.raw(error));
+            return;
         }
+        plugin.getTelemetryEvents().recordUsage("settings_announcement_reviewed", "Opened settings from announcement.");
     }
 
     private void persistOptOutIfRequested(@Nonnull UUID playerUuid,

--- a/src/main/resources/telemetry/project.json
+++ b/src/main/resources/telemetry/project.json
@@ -22,8 +22,8 @@
     "destinationMode": "hosted"
   },
   "hosted": {
-    "endpoint": "http://178.156.251.66:8797/ingest/crash",
-    "eventEndpoint": "http://178.156.251.66:8797/ingest/event",
+    "endpoint": "https://telemetry.alecsmods.com/ingest/crash",
+    "eventEndpoint": "https://telemetry.alecsmods.com/ingest/event",
     "projectKey": "dev_tamework_local_test"
   }
 }

--- a/src/main/resources/telemetry/project.json
+++ b/src/main/resources/telemetry/project.json
@@ -12,11 +12,18 @@
     "enabled": true,
     "allowedEvents": [
       "reload_config_command_used",
-      "settings_page_opened"
+      "settings_page_opened",
+      "news_command_opened",
+      "settings_announcement_opened",
+      "settings_announcement_reviewed"
     ]
   },
   "defaults": {
     "destinationMode": "hosted"
   },
-  "hosted": {}
+  "hosted": {
+    "endpoint": "http://178.156.251.66:8797/ingest/crash",
+    "eventEndpoint": "http://178.156.251.66:8797/ingest/event",
+    "projectKey": "dev_tamework_local_test"
+  }
 }


### PR DESCRIPTION
## Summary
- bake the publishable hosted telemetry key and endpoints directly into Tamework's shipped descriptor
- add more real usage and handled-error telemetry around `/tw news` and settings announcements
- align Tamework's out-of-the-box hosted telemetry flow with the publishable-key model

## Validation
- .\mvnw test