### PR TITLE
[codex] Add typed telemetry context

### DIFF
--- a/src/main/java/com/alechilles/alecstamework/Tamework.java
+++ b/src/main/java/com/alechilles/alecstamework/Tamework.java
@@ -266,16 +266,66 @@ public class Tamework extends JavaPlugin {
         try {
             setupInternal();
             int durationMs = telemetryEvents.elapsedMillis(startedAtNanos);
-            telemetryEvents.recordLifecycle("plugin_setup", durationMs, true, "Tamework setupInternal completed.");
-            telemetryEvents.recordPerformance("plugin_setup_duration", durationMs, (double) durationMs, "Tamework plugin setup duration.");
+            telemetryEvents.recordLifecycle(
+                    "plugin_setup",
+                    durationMs,
+                    true,
+                    TameworkTelemetryEvents.context()
+                            .subsystem("plugin")
+                            .phase("setup")
+                            .operation("setupInternal")
+                            .detail("Tamework setupInternal completed.")
+                            .build()
+            );
+            telemetryEvents.recordPerformance(
+                    "plugin_setup_duration",
+                    durationMs,
+                    (double) durationMs,
+                    TameworkTelemetryEvents.context()
+                            .subsystem("plugin")
+                            .phase("setup")
+                            .operation("setupInternal")
+                            .detail("Tamework plugin setup duration.")
+                            .build()
+            );
             if (crashTelemetryService != null) {
                 crashTelemetryService.recordBreadcrumb("lifecycle", "Tamework setup completed.");
             }
         } catch (Throwable throwable) {
             int durationMs = telemetryEvents.elapsedMillis(startedAtNanos);
-            telemetryEvents.recordLifecycle("plugin_setup", durationMs, false, "Tamework setupInternal failed.");
-            telemetryEvents.recordPerformance("plugin_setup_duration", durationMs, (double) durationMs, "Failed Tamework plugin setup duration.");
-            telemetryEvents.recordError("plugin_setup_failed", throwable, "Tamework setupInternal threw an exception.");
+            telemetryEvents.recordLifecycle(
+                    "plugin_setup",
+                    durationMs,
+                    false,
+                    TameworkTelemetryEvents.context()
+                            .subsystem("plugin")
+                            .phase("setup")
+                            .operation("setupInternal")
+                            .detail("Tamework setupInternal failed.")
+                            .build()
+            );
+            telemetryEvents.recordPerformance(
+                    "plugin_setup_duration",
+                    durationMs,
+                    (double) durationMs,
+                    TameworkTelemetryEvents.context()
+                            .subsystem("plugin")
+                            .phase("setup")
+                            .operation("setupInternal")
+                            .detail("Failed Tamework plugin setup duration.")
+                            .detail("result", "failed")
+                            .build()
+            );
+            telemetryEvents.recordError(
+                    "plugin_setup_failed",
+                    throwable,
+                    TameworkTelemetryEvents.context()
+                            .subsystem("plugin")
+                            .phase("setup")
+                            .operation("setupInternal")
+                            .detail("Tamework setupInternal threw an exception.")
+                            .build()
+            );
             captureSetupFailure(throwable);
             throw throwable;
         }
@@ -766,16 +816,66 @@ public class Tamework extends JavaPlugin {
         try {
             startInternal();
             int durationMs = telemetryEvents.elapsedMillis(startedAtNanos);
-            telemetryEvents.recordLifecycle("plugin_start", durationMs, true, "Tamework startInternal completed.");
-            telemetryEvents.recordPerformance("plugin_start_duration", durationMs, (double) durationMs, "Tamework plugin start duration.");
+            telemetryEvents.recordLifecycle(
+                    "plugin_start",
+                    durationMs,
+                    true,
+                    TameworkTelemetryEvents.context()
+                            .subsystem("plugin")
+                            .phase("start")
+                            .operation("startInternal")
+                            .detail("Tamework startInternal completed.")
+                            .build()
+            );
+            telemetryEvents.recordPerformance(
+                    "plugin_start_duration",
+                    durationMs,
+                    (double) durationMs,
+                    TameworkTelemetryEvents.context()
+                            .subsystem("plugin")
+                            .phase("start")
+                            .operation("startInternal")
+                            .detail("Tamework plugin start duration.")
+                            .build()
+            );
             if (crashTelemetryService != null) {
                 crashTelemetryService.recordBreadcrumb("lifecycle", "Tamework start completed.");
             }
         } catch (Throwable throwable) {
             int durationMs = telemetryEvents.elapsedMillis(startedAtNanos);
-            telemetryEvents.recordLifecycle("plugin_start", durationMs, false, "Tamework startInternal failed.");
-            telemetryEvents.recordPerformance("plugin_start_duration", durationMs, (double) durationMs, "Failed Tamework plugin start duration.");
-            telemetryEvents.recordError("plugin_start_failed", throwable, "Tamework startInternal threw an exception.");
+            telemetryEvents.recordLifecycle(
+                    "plugin_start",
+                    durationMs,
+                    false,
+                    TameworkTelemetryEvents.context()
+                            .subsystem("plugin")
+                            .phase("start")
+                            .operation("startInternal")
+                            .detail("Tamework startInternal failed.")
+                            .build()
+            );
+            telemetryEvents.recordPerformance(
+                    "plugin_start_duration",
+                    durationMs,
+                    (double) durationMs,
+                    TameworkTelemetryEvents.context()
+                            .subsystem("plugin")
+                            .phase("start")
+                            .operation("startInternal")
+                            .detail("Failed Tamework plugin start duration.")
+                            .detail("result", "failed")
+                            .build()
+            );
+            telemetryEvents.recordError(
+                    "plugin_start_failed",
+                    throwable,
+                    TameworkTelemetryEvents.context()
+                            .subsystem("plugin")
+                            .phase("start")
+                            .operation("startInternal")
+                            .detail("Tamework startInternal threw an exception.")
+                            .build()
+            );
             captureStartFailure(throwable);
             throw throwable;
         }
@@ -897,11 +997,14 @@ public class Tamework extends JavaPlugin {
             telemetryEvents.recordError(
                     "world_override_reload_errors",
                     null,
-                    "Loaded overrides for world "
-                            + world.getName()
-                            + " with "
-                            + reloadResult.getErrors().size()
-                            + " error(s)."
+                    TameworkTelemetryEvents.context()
+                            .subsystem("config")
+                            .featureKey("config_overrides")
+                            .operation("reload_overrides")
+                            .target("world_overrides")
+                            .detail("Loaded overrides with " + reloadResult.getErrors().size() + " error(s).")
+                            .detail("overrideErrorCount", reloadResult.getErrors().size())
+                            .build()
             );
             getLogger().at(Level.WARNING).log(
                     "Loaded Tamework overrides for world "

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkConfigCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkConfigCommand.java
@@ -1,6 +1,7 @@
 package com.alechilles.alecstamework.commands;
 
 import com.alechilles.alecstamework.Tamework;
+import com.alechilles.alecstamework.metrics.TameworkTelemetryEvents;
 import com.alechilles.alecstamework.ui.TameworkConfigEditorPage;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
@@ -55,12 +56,24 @@ public final class TameworkConfigCommand extends AbstractPlayerCommand {
         try {
             TameworkConfigEditorPage page = new TameworkConfigEditorPage(uiPlayerRef, plugin, world);
             player.getPageManager().openCustomPage(ref, store, page);
-            plugin.getTelemetryEvents().recordUsage("config_editor_opened", "Opened via /tw config.");
+            plugin.getTelemetryEvents().recordUsage(
+                    "config_editor_opened",
+                    TameworkTelemetryEvents.commandContext("/tw config", "config_editor", "config_editor")
+                            .operation("open")
+                            .detail("Opened via /tw config.")
+                            .detail("source", "command")
+                            .build()
+            );
         } catch (Throwable throwable) {
             plugin.getTelemetryEvents().recordError(
                     "ui_page_open_failed",
                     throwable,
-                    "page=TameworkConfigEditorPage action=/tw config"
+                    TameworkTelemetryEvents.commandContext("/tw config", "config_editor", "config_editor")
+                            .operation("open")
+                            .target("TameworkConfigEditorPage")
+                            .detail("Failed to open Tamework config editor page.")
+                            .detail("source", "command")
+                            .build()
             );
             commandContext.sender().sendMessage(Message.raw("Unable to open the config editor right now."));
         }

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkDebugCrashTelemetryCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkDebugCrashTelemetryCommand.java
@@ -3,6 +3,7 @@ package com.alechilles.alecstamework.commands;
 import com.alechilles.alecstamework.Tamework;
 import com.alechilles.alecstamework.metrics.CrashTelemetryDiagnostics;
 import com.alechilles.alecstamework.metrics.CrashTelemetryService;
+import com.alechilles.alecstamework.metrics.TameworkTelemetryEvents;
 import com.hypixel.hytale.server.core.HytaleServer;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
@@ -74,7 +75,17 @@ public final class TameworkDebugCrashTelemetryCommand extends AbstractPlayerComm
             boolean recorded = crashTelemetryService.recordError(
                     "debug_command_error",
                     new IllegalStateException("Simulated Tamework telemetry error event (" + token + ")"),
-                    "Triggered by /tw debugcrashtelemetry eventerror (token=" + token + ")"
+                    TameworkTelemetryEvents.commandContext(
+                                    "/tw debugcrashtelemetry",
+                                    "telemetry_debug",
+                                    "crash_telemetry_debug"
+                            )
+                            .operation("eventerror")
+                            .detail("Triggered by /tw debugcrashtelemetry eventerror.")
+                            .detail("source", "debug_command")
+                            .detail("debugAction", "eventerror")
+                            .detail("debugToken", token)
+                            .build()
             );
             commandContext.sender().sendMessage(Message.raw(
                     recorded
@@ -95,7 +106,17 @@ public final class TameworkDebugCrashTelemetryCommand extends AbstractPlayerComm
                     "debug_command_lifecycle",
                     123,
                     true,
-                    "Triggered by /tw debugcrashtelemetry eventlifecycle (token=" + token + ")"
+                    TameworkTelemetryEvents.commandContext(
+                                    "/tw debugcrashtelemetry",
+                                    "telemetry_debug",
+                                    "crash_telemetry_debug"
+                            )
+                            .operation("eventlifecycle")
+                            .detail("Triggered by /tw debugcrashtelemetry eventlifecycle.")
+                            .detail("source", "debug_command")
+                            .detail("debugAction", "eventlifecycle")
+                            .detail("debugToken", token)
+                            .build()
             );
             commandContext.sender().sendMessage(Message.raw(
                     recorded

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkNewsCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkNewsCommand.java
@@ -1,6 +1,7 @@
 package com.alechilles.alecstamework.commands;
 
 import com.alechilles.alecstamework.Tamework;
+import com.alechilles.alecstamework.metrics.TameworkTelemetryEvents;
 import com.alechilles.alecstamework.ui.TameworkSettingsAnnouncementService;
 import com.alechilles.alecstamework.ui.TameworkSettingsPageService;
 import com.hypixel.hytale.component.Ref;
@@ -61,10 +62,25 @@ public final class TameworkNewsCommand extends AbstractPlayerCommand {
 
         String error = service.openAnnouncementNow(ref, store, player);
         if (error != null) {
-            plugin.getTelemetryEvents().recordError("news_command_open_failed", null, error);
+            plugin.getTelemetryEvents().recordError(
+                    "news_command_open_failed",
+                    null,
+                    TameworkTelemetryEvents.commandContext("/tw news", "news", "news")
+                            .operation("open")
+                            .detail(error)
+                            .detail("source", "command")
+                            .build()
+            );
             commandContext.sender().sendMessage(Message.raw(error));
             return;
         }
-        plugin.getTelemetryEvents().recordUsage("news_command_opened", "Opened via /tw news.");
+        plugin.getTelemetryEvents().recordUsage(
+                "news_command_opened",
+                TameworkTelemetryEvents.commandContext("/tw news", "news", "news")
+                        .operation("open")
+                        .detail("Opened via /tw news.")
+                        .detail("source", "command")
+                        .build()
+        );
     }
 }

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkReloadConfigCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkReloadConfigCommand.java
@@ -4,6 +4,7 @@ import com.alechilles.alecstamework.Tamework;
 import com.alechilles.alecstamework.config.overrides.TwConfigOverrideManager;
 import com.alechilles.alecstamework.metrics.TameworkTelemetryEvents;
 import com.alechilles.alecstamework.persistence.TameworkSettingsStore;
+import com.alechilles.alecstelemetry.api.TelemetryEventContext;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.server.core.Message;
@@ -20,6 +21,7 @@ import javax.annotation.Nonnull;
  * Reloads Tamework item feature configs from disk.
  */
 public final class TameworkReloadConfigCommand extends AbstractPlayerCommand {
+    private static final String COMMAND_NAME = "/tw reloadconfig";
 
     public TameworkReloadConfigCommand() {
         super("reloadconfig", "Reload Tamework item feature configs.");
@@ -39,7 +41,12 @@ public final class TameworkReloadConfigCommand extends AbstractPlayerCommand {
         }
         TameworkTelemetryEvents telemetryEvents = plugin.getTelemetryEvents();
         long startedAtNanos = System.nanoTime();
-        telemetryEvents.recordUsage("reload_config_command_used", "Triggered by /tw reloadconfig.");
+        telemetryEvents.recordUsage(
+                "reload_config_command_used",
+                reloadContext("Triggered by " + COMMAND_NAME + ".")
+                        .detail("source", "command")
+                        .build()
+        );
         commandContext.sender().sendMessage(Message.raw("Reloading Tamework configs..."));
         CompletableFuture.supplyAsync(() -> {
             TameworkSettingsStore.invalidateRuntimeGlobalOverridesCache();
@@ -56,20 +63,58 @@ public final class TameworkReloadConfigCommand extends AbstractPlayerCommand {
             int durationMs = telemetryEvents.elapsedMillis(startedAtNanos);
             if (throwable != null || summary == null) {
                 plugin.getLogger().at(Level.WARNING).withCause(throwable).log("Async /tw reloadconfig failed.");
-                telemetryEvents.recordLifecycle("reload_config", durationMs, false, "Async /tw reloadconfig failed.");
-                telemetryEvents.recordPerformance("reload_config_duration", durationMs, (double) durationMs, "Failed /tw reloadconfig duration.");
-                telemetryEvents.recordError("reload_config_failed", throwable, "Async /tw reloadconfig failed.");
+                telemetryEvents.recordLifecycle(
+                        "reload_config",
+                        durationMs,
+                        false,
+                        reloadContext("Async " + COMMAND_NAME + " failed.")
+                                .detail("source", "command")
+                                .detail("result", "failed")
+                                .build()
+                );
+                telemetryEvents.recordPerformance(
+                        "reload_config_duration",
+                        durationMs,
+                        (double) durationMs,
+                        reloadContext("Failed " + COMMAND_NAME + " duration.")
+                                .detail("result", "failed")
+                                .build()
+                );
+                telemetryEvents.recordError(
+                        "reload_config_failed",
+                        throwable,
+                        reloadContext("Async " + COMMAND_NAME + " failed.")
+                                .detail("source", "command")
+                                .detail("result", "failed")
+                                .build()
+                );
                 commandContext.sender().sendMessage(Message.raw("Reload failed. See server log for details."));
                 return;
             }
             plugin.applyDebugConfigDefaults();
-            telemetryEvents.recordLifecycle("reload_config", durationMs, true, "Reloaded Tamework configs via /tw reloadconfig.");
-            telemetryEvents.recordPerformance("reload_config_duration", durationMs, (double) durationMs, "Successful /tw reloadconfig duration.");
+            telemetryEvents.recordLifecycle(
+                    "reload_config",
+                    durationMs,
+                    true,
+                    reloadSummaryContext("Reloaded Tamework configs via " + COMMAND_NAME + ".", summary, "success")
+                            .detail("source", "command")
+                            .build()
+            );
+            telemetryEvents.recordPerformance(
+                    "reload_config_duration",
+                    durationMs,
+                    (double) durationMs,
+                    reloadSummaryContext("Successful " + COMMAND_NAME + " duration.", summary, "success").build()
+            );
             if (summary.reloadResult().hasErrors()) {
                 telemetryEvents.recordError(
                         "reload_config_override_errors",
                         null,
-                        "Reloaded with " + summary.reloadResult().getErrors().size() + " override error(s)."
+                        reloadSummaryContext(
+                                "Reloaded with " + summary.reloadResult().getErrors().size() + " override error(s).",
+                                summary,
+                                "partial"
+                        ).build()
                 );
             }
             commandContext.sender().sendMessage(Message.raw(
@@ -87,6 +132,27 @@ public final class TameworkReloadConfigCommand extends AbstractPlayerCommand {
                 ));
             }
         }));
+    }
+
+    @Nonnull
+    private static TelemetryEventContext.Builder reloadContext(@Nonnull String detail) {
+        return TameworkTelemetryEvents.commandContext(COMMAND_NAME, "config", "reload_config")
+                .operation("reload")
+                .detail(detail);
+    }
+
+    @Nonnull
+    private static TelemetryEventContext.Builder reloadSummaryContext(@Nonnull String detail,
+                                                                     @Nonnull ReloadSummary summary,
+                                                                     @Nonnull String result) {
+        return reloadContext(detail)
+                .detail("result", result)
+                .detail("itemConfigCount", summary.itemLoaded())
+                .detail("totalSpawners", summary.totalSpawners())
+                .detail("totalNaming", summary.totalNaming())
+                .detail("overridePacks", summary.reloadResult().getLoadedPacks())
+                .detail("overrideDirectories", summary.reloadResult().getLoadedDirectories())
+                .detail("overrideErrorCount", summary.reloadResult().getErrors().size());
     }
 
     private record ReloadSummary(@Nonnull TwConfigOverrideManager.ReloadResult reloadResult,

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkReloadConfigCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkReloadConfigCommand.java
@@ -92,11 +92,13 @@ public final class TameworkReloadConfigCommand extends AbstractPlayerCommand {
                 return;
             }
             plugin.applyDebugConfigDefaults();
+            String result = TameworkReloadConfigTelemetry.reloadResultLabel(summary.reloadResult());
+            boolean partial = "partial".equals(result);
             telemetryEvents.recordLifecycle(
                     "reload_config",
                     durationMs,
-                    true,
-                    reloadSummaryContext("Reloaded Tamework configs via " + COMMAND_NAME + ".", summary, "success")
+                    !partial,
+                    reloadSummaryContext("Reloaded Tamework configs via " + COMMAND_NAME + ".", summary, result)
                             .detail("source", "command")
                             .build()
             );
@@ -104,9 +106,9 @@ public final class TameworkReloadConfigCommand extends AbstractPlayerCommand {
                     "reload_config_duration",
                     durationMs,
                     (double) durationMs,
-                    reloadSummaryContext("Successful " + COMMAND_NAME + " duration.", summary, "success").build()
+                    reloadSummaryContext("Completed " + COMMAND_NAME + " duration.", summary, result).build()
             );
-            if (summary.reloadResult().hasErrors()) {
+            if (partial) {
                 telemetryEvents.recordError(
                         "reload_config_override_errors",
                         null,

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkReloadConfigTelemetry.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkReloadConfigTelemetry.java
@@ -1,0 +1,14 @@
+package com.alechilles.alecstamework.commands;
+
+import com.alechilles.alecstamework.config.overrides.TwConfigOverrideManager;
+import javax.annotation.Nonnull;
+
+final class TameworkReloadConfigTelemetry {
+    private TameworkReloadConfigTelemetry() {
+    }
+
+    @Nonnull
+    static String reloadResultLabel(@Nonnull TwConfigOverrideManager.ReloadResult reloadResult) {
+        return reloadResult.hasErrors() ? "partial" : "success";
+    }
+}

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkSettingsCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkSettingsCommand.java
@@ -39,7 +39,7 @@ public final class TameworkSettingsCommand extends AbstractPlayerCommand {
             commandContext.sender().sendMessage(Message.raw("You do not have permission to use /tw settings."));
             return;
         }
-        String error = TameworkSettingsPageService.openSettingsPage(ref, store, world);
+        String error = TameworkSettingsPageService.openSettingsPage(ref, store, world, "command", "/tw settings");
         if (error != null) {
             commandContext.sender().sendMessage(Message.raw(error));
         }

--- a/src/main/java/com/alechilles/alecstamework/metrics/CrashTelemetryService.java
+++ b/src/main/java/com/alechilles/alecstamework/metrics/CrashTelemetryService.java
@@ -1,5 +1,6 @@
 package com.alechilles.alecstamework.metrics;
 
+import com.alechilles.alecstelemetry.api.TelemetryEventContext;
 import com.alechilles.alecstelemetry.core.TelemetryCoreEngine;
 import com.alechilles.alecstelemetry.crash.CrashReportClient;
 import com.alechilles.alecstelemetry.crash.CrashReportEnvelope;
@@ -207,10 +208,16 @@ public final class CrashTelemetryService {
     public boolean recordError(@Nonnull String eventName,
                                @Nullable Throwable throwable,
                                @Nullable String detail) {
+        return recordError(eventName, throwable, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public boolean recordError(@Nonnull String eventName,
+                               @Nullable Throwable throwable,
+                               @Nullable TelemetryEventContext context) {
         if (!canRecordEvents()) {
             return false;
         }
-        engine.recordError(project.projectId(), eventName, throwable, detail);
+        engine.recordError(project.projectId(), eventName, throwable, context);
         syncLastFlushStatus();
         return true;
     }
@@ -219,10 +226,17 @@ public final class CrashTelemetryService {
                                    int durationMs,
                                    boolean success,
                                    @Nullable String detail) {
+        return recordLifecycle(eventName, durationMs, success, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public boolean recordLifecycle(@Nonnull String eventName,
+                                   int durationMs,
+                                   boolean success,
+                                   @Nullable TelemetryEventContext context) {
         if (!canRecordEvents()) {
             return false;
         }
-        engine.recordLifecycle(project.projectId(), eventName, durationMs, success, detail);
+        engine.recordLifecycle(project.projectId(), eventName, durationMs, success, context);
         syncLastFlushStatus();
         return true;
     }
@@ -231,19 +245,31 @@ public final class CrashTelemetryService {
                                   int durationMs,
                                   @Nullable Double metricValue,
                                   @Nullable String detail) {
+        recordPerformance(eventName, durationMs, metricValue, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public void recordPerformance(@Nonnull String eventName,
+                                  int durationMs,
+                                  @Nullable Double metricValue,
+                                  @Nullable TelemetryEventContext context) {
         if (!canRecordEvents()) {
             return;
         }
-        engine.recordPerformance(project.projectId(), eventName, durationMs, metricValue, detail);
+        engine.recordPerformance(project.projectId(), eventName, durationMs, metricValue, context);
         syncLastFlushStatus();
     }
 
     public void recordUsage(@Nonnull String eventName,
                             @Nullable String detail) {
+        recordUsage(eventName, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public void recordUsage(@Nonnull String eventName,
+                            @Nullable TelemetryEventContext context) {
         if (!canRecordEvents()) {
             return;
         }
-        engine.recordUsage(project.projectId(), eventName, detail);
+        engine.recordUsage(project.projectId(), eventName, context);
         syncLastFlushStatus();
     }
 

--- a/src/main/java/com/alechilles/alecstamework/metrics/CrashTelemetryService.java
+++ b/src/main/java/com/alechilles/alecstamework/metrics/CrashTelemetryService.java
@@ -214,12 +214,12 @@ public final class CrashTelemetryService {
     public boolean recordError(@Nonnull String eventName,
                                @Nullable Throwable throwable,
                                @Nullable TelemetryEventContext context) {
-        if (!canRecordEvents() || !project.events().errors().enabled()) {
+        if (!canRecordEvents()) {
             return false;
         }
-        engine.recordError(project.projectId(), eventName, throwable, context);
+        boolean recorded = engine.recordError(project.projectId(), eventName, throwable, context);
         syncLastFlushStatus();
-        return true;
+        return recorded;
     }
 
     public boolean recordLifecycle(@Nonnull String eventName,
@@ -233,12 +233,12 @@ public final class CrashTelemetryService {
                                    int durationMs,
                                    boolean success,
                                    @Nullable TelemetryEventContext context) {
-        if (!canRecordEvents() || !project.events().lifecycle().enabled()) {
+        if (!canRecordEvents()) {
             return false;
         }
-        engine.recordLifecycle(project.projectId(), eventName, durationMs, success, context);
+        boolean recorded = engine.recordLifecycle(project.projectId(), eventName, durationMs, success, context);
         syncLastFlushStatus();
-        return true;
+        return recorded;
     }
 
     public void recordPerformance(@Nonnull String eventName,

--- a/src/main/java/com/alechilles/alecstamework/metrics/CrashTelemetryService.java
+++ b/src/main/java/com/alechilles/alecstamework/metrics/CrashTelemetryService.java
@@ -214,7 +214,7 @@ public final class CrashTelemetryService {
     public boolean recordError(@Nonnull String eventName,
                                @Nullable Throwable throwable,
                                @Nullable TelemetryEventContext context) {
-        if (!canRecordEvents()) {
+        if (!canRecordEvents() || !project.events().errors().enabled()) {
             return false;
         }
         engine.recordError(project.projectId(), eventName, throwable, context);
@@ -233,7 +233,7 @@ public final class CrashTelemetryService {
                                    int durationMs,
                                    boolean success,
                                    @Nullable TelemetryEventContext context) {
-        if (!canRecordEvents()) {
+        if (!canRecordEvents() || !project.events().lifecycle().enabled()) {
             return false;
         }
         engine.recordLifecycle(project.projectId(), eventName, durationMs, success, context);

--- a/src/main/java/com/alechilles/alecstamework/metrics/TameworkTelemetryEvents.java
+++ b/src/main/java/com/alechilles/alecstamework/metrics/TameworkTelemetryEvents.java
@@ -1,6 +1,7 @@
 package com.alechilles.alecstamework.metrics;
 
 import com.alechilles.alecstamework.Tamework;
+import com.alechilles.alecstelemetry.api.TelemetryEventContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -10,12 +11,41 @@ import javax.annotation.Nullable;
  */
 public final class TameworkTelemetryEvents {
 
+    @Nonnull
+    public static TelemetryEventContext.Builder context() {
+        return TelemetryEventContext.builder().runtimeSide("server");
+    }
+
+    @Nonnull
+    public static TelemetryEventContext.Builder featureContext(@Nonnull String subsystem,
+                                                              @Nonnull String featureKey,
+                                                              @Nullable String entryPoint) {
+        return context()
+                .subsystem(subsystem)
+                .featureKey(featureKey)
+                .entryPoint(entryPoint);
+    }
+
+    @Nonnull
+    public static TelemetryEventContext.Builder commandContext(@Nonnull String commandName,
+                                                              @Nonnull String subsystem,
+                                                              @Nonnull String featureKey) {
+        return featureContext(subsystem, featureKey, commandName)
+                .commandName(commandName);
+    }
+
     public void recordError(@Nonnull String eventName,
                             @Nullable Throwable throwable,
                             @Nullable String detail) {
+        recordError(eventName, throwable, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public void recordError(@Nonnull String eventName,
+                            @Nullable Throwable throwable,
+                            @Nullable TelemetryEventContext context) {
         CrashTelemetryService service = resolveService();
         if (service != null) {
-            service.recordError(eventName, throwable, detail);
+            service.recordError(eventName, throwable, context);
         }
     }
 
@@ -23,9 +53,16 @@ public final class TameworkTelemetryEvents {
                                 int durationMs,
                                 boolean success,
                                 @Nullable String detail) {
+        recordLifecycle(eventName, durationMs, success, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public void recordLifecycle(@Nonnull String eventName,
+                                int durationMs,
+                                boolean success,
+                                @Nullable TelemetryEventContext context) {
         CrashTelemetryService service = resolveService();
         if (service != null) {
-            service.recordLifecycle(eventName, durationMs, success, detail);
+            service.recordLifecycle(eventName, durationMs, success, context);
         }
     }
 
@@ -33,17 +70,29 @@ public final class TameworkTelemetryEvents {
                                   int durationMs,
                                   @Nullable Double metricValue,
                                   @Nullable String detail) {
+        recordPerformance(eventName, durationMs, metricValue, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public void recordPerformance(@Nonnull String eventName,
+                                  int durationMs,
+                                  @Nullable Double metricValue,
+                                  @Nullable TelemetryEventContext context) {
         CrashTelemetryService service = resolveService();
         if (service != null) {
-            service.recordPerformance(eventName, durationMs, metricValue, detail);
+            service.recordPerformance(eventName, durationMs, metricValue, context);
         }
     }
 
     public void recordUsage(@Nonnull String eventName,
                             @Nullable String detail) {
+        recordUsage(eventName, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public void recordUsage(@Nonnull String eventName,
+                            @Nullable TelemetryEventContext context) {
         CrashTelemetryService service = resolveService();
         if (service != null) {
-            service.recordUsage(eventName, detail);
+            service.recordUsage(eventName, context);
         }
     }
 
@@ -59,10 +108,16 @@ public final class TameworkTelemetryEvents {
     public static void recordErrorIfAvailable(@Nonnull String eventName,
                                               @Nullable Throwable throwable,
                                               @Nullable String detail) {
+        recordErrorIfAvailable(eventName, throwable, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public static void recordErrorIfAvailable(@Nonnull String eventName,
+                                              @Nullable Throwable throwable,
+                                              @Nullable TelemetryEventContext context) {
         try {
             TameworkTelemetryEvents telemetry = resolveAvailable();
             if (telemetry != null) {
-                telemetry.recordError(eventName, throwable, detail);
+                telemetry.recordError(eventName, throwable, context);
             }
         } catch (Throwable ignored) {
         }
@@ -70,10 +125,15 @@ public final class TameworkTelemetryEvents {
 
     public static void recordUsageIfAvailable(@Nonnull String eventName,
                                               @Nullable String detail) {
+        recordUsageIfAvailable(eventName, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public static void recordUsageIfAvailable(@Nonnull String eventName,
+                                              @Nullable TelemetryEventContext context) {
         try {
             TameworkTelemetryEvents telemetry = resolveAvailable();
             if (telemetry != null) {
-                telemetry.recordUsage(eventName, detail);
+                telemetry.recordUsage(eventName, context);
             }
         } catch (Throwable ignored) {
         }

--- a/src/main/java/com/alechilles/alecstamework/ui/TameworkConfigEditorPage.java
+++ b/src/main/java/com/alechilles/alecstamework/ui/TameworkConfigEditorPage.java
@@ -7,6 +7,8 @@ import com.alechilles.alecstamework.config.overrides.TwConfigJsonUtil;
 import com.alechilles.alecstamework.config.overrides.TwConfigOverrideManager;
 import com.alechilles.alecstamework.config.overrides.TwConfigSnapshot;
 import com.alechilles.alecstamework.localization.LocalizedText;
+import com.alechilles.alecstamework.metrics.TameworkTelemetryEvents;
+import com.alechilles.alecstelemetry.api.TelemetryEventContext;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -127,7 +129,9 @@ public final class TameworkConfigEditorPage
             plugin.getTelemetryEvents().recordError(
                     "ui_page_build_failed",
                     throwable,
-                    "page=TameworkConfigEditorPage"
+                    configEditorContext("build", "Failed to build Tamework config editor page.")
+                            .target("TameworkConfigEditorPage")
+                            .build()
             );
             throw throwable;
         }
@@ -253,7 +257,12 @@ public final class TameworkConfigEditorPage
             statusLine = "";
             return;
         }
-        plugin.getTelemetryEvents().recordUsage("config_editor_apply_requested", "Apply requested from /tw config.");
+        plugin.getTelemetryEvents().recordUsage(
+                "config_editor_apply_requested",
+                configEditorContext("apply_request", "Apply requested from /tw config.")
+                        .detail("changedFileCount", pendingDraftFileCount())
+                        .build()
+        );
         applyConfirmVisible = false;
         String validationError = firstValidationError();
         if (validationError != null) {
@@ -282,6 +291,7 @@ public final class TameworkConfigEditorPage
 
         TwConfigSnapshot snapshotAtSubmit = snapshot;
         TwConfigAssetDescriptor selectedAtSubmit = selectedDescriptor();
+        int changedFileCountAtSubmit = pendingDraftFileCount();
         LinkedHashMap<TwConfigAssetDescriptor, JsonObject> drafted = new LinkedHashMap<>();
         for (TwConfigAssetDescriptor descriptor : descriptorByKey.values()) {
             drafted.put(descriptor, TwConfigJsonUtil.copyObject(draftByKey.get(descriptor.descriptorKey())));
@@ -301,7 +311,10 @@ public final class TameworkConfigEditorPage
                         plugin.getTelemetryEvents().recordError(
                                 "config_editor_apply_failed",
                                 throwable,
-                                "Async /tw config apply failed."
+                                configEditorContext("apply", "Async /tw config apply failed.")
+                                        .detail("changedFileCount", changedFileCountAtSubmit)
+                                        .detail("result", "failed")
+                                        .build()
                         );
                         statusLine = "";
                         warningLine = tr("tamework.ui.configEditor.warning.applyFailed");
@@ -311,7 +324,10 @@ public final class TameworkConfigEditorPage
                     if (result.isSuccess()) {
                         plugin.getTelemetryEvents().recordUsage(
                                 "config_editor_apply_succeeded",
-                                "Applied overrides from /tw config."
+                                configEditorContext("apply", "Applied overrides from /tw config.")
+                                        .detail("changedFileCount", changedFileCountAtSubmit)
+                                        .detail("result", "success")
+                                        .build()
                         );
                         reloadSnapshot(false);
                         statusLine = result.getMessage();
@@ -322,7 +338,10 @@ public final class TameworkConfigEditorPage
                     plugin.getTelemetryEvents().recordError(
                             "config_editor_apply_failed",
                             null,
-                            result.getMessage()
+                            configEditorContext("apply", result.getMessage())
+                                    .detail("changedFileCount", changedFileCountAtSubmit)
+                                    .detail("result", result.isStale() ? "stale" : "failed")
+                                    .build()
                     );
                     statusLine = "";
                     warningLine = result.getMessage();
@@ -1614,6 +1633,14 @@ public final class TameworkConfigEditorPage
             }
         }
         return count;
+    }
+
+    @Nonnull
+    private TelemetryEventContext.Builder configEditorContext(@Nonnull String operation, @Nonnull String detail) {
+        return TameworkTelemetryEvents.featureContext("config_editor", "config_editor", "/tw config")
+                .operation(operation)
+                .detail(detail)
+                .detail("source", "settings_ui");
     }
 
     @Nullable

--- a/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsAnnouncementService.java
+++ b/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsAnnouncementService.java
@@ -2,6 +2,7 @@ package com.alechilles.alecstamework.ui;
 
 import com.alechilles.alecstamework.Tamework;
 import com.alechilles.alecstamework.localization.LocalizedText;
+import com.alechilles.alecstamework.metrics.TameworkTelemetryEvents;
 import com.alechilles.alecstamework.persistence.TameworkSettingsAnnouncementStore;
 import com.alechilles.alecstamework.persistence.TameworkSettingsAnnouncementStore.AnnouncementOptOutState;
 import com.alechilles.alecstamework.persistence.TameworkSettingsAnnouncementStore.ResolvedAnnouncement;
@@ -120,13 +121,25 @@ public final class TameworkSettingsAnnouncementService {
         );
         try {
             player.getPageManager().openCustomPage(playerRef, store, page);
-            plugin.getTelemetryEvents().recordUsage("settings_announcement_opened", "Opened Tamework settings announcement.");
+            plugin.getTelemetryEvents().recordUsage(
+                    "settings_announcement_opened",
+                    TameworkTelemetryEvents.featureContext("settings", "settings_announcement", "settings_announcement")
+                            .operation("open")
+                            .detail("Opened Tamework settings announcement.")
+                            .detail("source", "announcement")
+                            .build()
+            );
             return null;
         } catch (Throwable throwable) {
             plugin.getTelemetryEvents().recordError(
                     "ui_page_open_failed",
                     throwable,
-                    "page=TameworkSettingsAnnouncementPage action=/tw news"
+                    TameworkTelemetryEvents.featureContext("settings", "settings_announcement", "settings_announcement")
+                            .operation("open")
+                            .target("TameworkSettingsAnnouncementPage")
+                            .detail("Failed to open Tamework settings announcement.")
+                            .detail("source", "announcement")
+                            .build()
             );
             return respectEnabled ? null : "Unable to open Tamework news right now.";
         }
@@ -187,15 +200,30 @@ public final class TameworkSettingsAnnouncementService {
                                   @Nonnull PlayerRef playerRef,
                                   @Nonnull UUID playerUuid,
                                   @Nonnull String announcementId,
-                                  boolean suppressUntilNextAnnouncement) {
+        boolean suppressUntilNextAnnouncement) {
         persistOptOutIfRequested(playerUuid, announcementId, suppressUntilNextAnnouncement);
-        String error = TameworkSettingsPageService.openSettingsPage(ref, store);
+        String error = TameworkSettingsPageService.openSettingsPage(ref, store, "announcement", "settings_announcement");
         if (error != null) {
-            plugin.getTelemetryEvents().recordError("settings_announcement_review_failed", null, error);
+            plugin.getTelemetryEvents().recordError(
+                    "settings_announcement_review_failed",
+                    null,
+                    TameworkTelemetryEvents.featureContext("settings", "settings_announcement", "settings_announcement")
+                            .operation("review_settings")
+                            .detail(error)
+                            .detail("source", "announcement")
+                            .build()
+            );
             playerRef.sendMessage(Message.raw(error));
             return;
         }
-        plugin.getTelemetryEvents().recordUsage("settings_announcement_reviewed", "Opened settings from announcement.");
+        plugin.getTelemetryEvents().recordUsage(
+                "settings_announcement_reviewed",
+                TameworkTelemetryEvents.featureContext("settings", "settings_announcement", "settings_announcement")
+                        .operation("review_settings")
+                        .detail("Opened settings from announcement.")
+                        .detail("source", "announcement")
+                        .build()
+        );
     }
 
     private void persistOptOutIfRequested(@Nonnull UUID playerUuid,
@@ -215,7 +243,11 @@ public final class TameworkSettingsAnnouncementService {
         plugin.getTelemetryEvents().recordError(
                 "settings_announcement_opt_out_persist_failed",
                 null,
-                "Failed to persist announcement opt-out for player " + playerUuid + "."
+                TameworkTelemetryEvents.featureContext("settings", "settings_announcement", "settings_announcement")
+                        .operation("persist_opt_out")
+                        .detail("Failed to persist announcement opt-out.")
+                        .detail("source", "announcement")
+                        .build()
         );
         plugin.getLogger().at(Level.WARNING).log(
                 "Failed to persist Tamework settings announcement opt-out for player " + playerUuid + "."

--- a/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsPage.java
+++ b/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsPage.java
@@ -5,6 +5,7 @@ import com.alechilles.alecstamework.config.assets.TwGlobalConfig;
 import com.alechilles.alecstamework.config.assets.TwNeedsConfig;
 import com.alechilles.alecstamework.metrics.CrashTelemetryService;
 import com.alechilles.alecstamework.metrics.CrashTelemetrySettings;
+import com.alechilles.alecstamework.metrics.TameworkTelemetryEvents;
 import com.alechilles.alecstamework.persistence.TameworkSettingsStore;
 import com.hypixel.hytale.codec.Codec;
 import com.hypixel.hytale.codec.KeyedCodec;
@@ -108,7 +109,12 @@ public final class TameworkSettingsPage extends InteractiveCustomUIPage<Tamework
             plugin.getTelemetryEvents().recordError(
                     "ui_page_build_failed",
                     throwable,
-                    "page=TameworkSettingsPage"
+                    TameworkTelemetryEvents.featureContext("settings", "settings_page", "/tw settings")
+                            .operation("build")
+                            .target("TameworkSettingsPage")
+                            .detail("Failed to build Tamework settings page.")
+                            .detail("source", "settings_ui")
+                            .build()
             );
             throw throwable;
         }

--- a/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsPageService.java
+++ b/src/main/java/com/alechilles/alecstamework/ui/TameworkSettingsPageService.java
@@ -2,6 +2,7 @@ package com.alechilles.alecstamework.ui;
 
 import com.alechilles.alecstamework.Tamework;
 import com.alechilles.alecstamework.commands.TameworkConfigPermission;
+import com.alechilles.alecstamework.metrics.TameworkTelemetryEvents;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.server.core.command.system.CommandSender;
@@ -55,12 +56,20 @@ public final class TameworkSettingsPageService {
         if (!hasAccess(playerRef, player)) {
             return "You do not have permission to use /tw settings.";
         }
-        return openSettingsPage(player, ref, store, world);
+        return openSettingsPage(player, ref, store, world, "api", "settings_api");
     }
 
     @Nullable
     public static String openSettingsPage(@Nonnull Ref<EntityStore> ref,
                                           @Nonnull Store<EntityStore> store) {
+        return openSettingsPage(ref, store, "api", "settings_api");
+    }
+
+    @Nullable
+    public static String openSettingsPage(@Nonnull Ref<EntityStore> ref,
+                                          @Nonnull Store<EntityStore> store,
+                                          @Nonnull String telemetrySource,
+                                          @Nonnull String entryPoint) {
         if (store.getExternalData() == null) {
             return "Unable to open settings right now.";
         }
@@ -68,25 +77,36 @@ public final class TameworkSettingsPageService {
         if (world == null) {
             return "Unable to open settings right now.";
         }
-        return openSettingsPage(ref, store, world);
+        return openSettingsPage(ref, store, world, telemetrySource, entryPoint);
     }
 
     @Nullable
     public static String openSettingsPage(@Nonnull Ref<EntityStore> ref,
                                           @Nonnull Store<EntityStore> store,
                                           @Nonnull World world) {
+        return openSettingsPage(ref, store, world, "api", "settings_api");
+    }
+
+    @Nullable
+    public static String openSettingsPage(@Nonnull Ref<EntityStore> ref,
+                                          @Nonnull Store<EntityStore> store,
+                                          @Nonnull World world,
+                                          @Nonnull String telemetrySource,
+                                          @Nonnull String entryPoint) {
         Player player = store.getComponent(ref, Player.getComponentType());
         if (player == null) {
             return "Unable to open settings right now.";
         }
-        return openSettingsPage(player, ref, store, world);
+        return openSettingsPage(player, ref, store, world, telemetrySource, entryPoint);
     }
 
     @Nullable
     private static String openSettingsPage(@Nonnull Player player,
                                            @Nonnull Ref<EntityStore> ref,
                                            @Nonnull Store<EntityStore> store,
-                                           @Nonnull World world) {
+                                           @Nonnull World world,
+                                           @Nonnull String telemetrySource,
+                                           @Nonnull String entryPoint) {
         Tamework plugin = Tamework.getInstance();
         if (plugin == null) {
             return "Tamework settings are not available.";
@@ -104,13 +124,25 @@ public final class TameworkSettingsPageService {
         try {
             TameworkSettingsPage page = new TameworkSettingsPage(uiPlayerRef, plugin, world);
             player.getPageManager().openCustomPage(ref, store, page);
-            plugin.getTelemetryEvents().recordUsage("settings_page_opened", "Opened via /tw settings.");
+            plugin.getTelemetryEvents().recordUsage(
+                    "settings_page_opened",
+                    TameworkTelemetryEvents.featureContext("settings", "settings_page", entryPoint)
+                            .operation("open")
+                            .detail("Opened Tamework settings page.")
+                            .detail("source", telemetrySource)
+                            .build()
+            );
             return null;
         } catch (Throwable throwable) {
             plugin.getTelemetryEvents().recordError(
                     "ui_page_open_failed",
                     throwable,
-                    "page=TameworkSettingsPage action=/tw settings"
+                    TameworkTelemetryEvents.featureContext("settings", "settings_page", entryPoint)
+                            .operation("open")
+                            .target("TameworkSettingsPage")
+                            .detail("Failed to open Tamework settings page.")
+                            .detail("source", telemetrySource)
+                            .build()
             );
             return "Unable to open settings right now.";
         }

--- a/src/main/java/com/alechilles/alecstelemetry/api/TelemetryEventContext.java
+++ b/src/main/java/com/alechilles/alecstelemetry/api/TelemetryEventContext.java
@@ -1,0 +1,274 @@
+package com.alechilles.alecstelemetry.api;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Optional typed context attached to non-crash telemetry events.
+ */
+public record TelemetryEventContext(@Nullable String detail,
+                                    @Nullable String severity,
+                                    @Nullable String fingerprint,
+                                    @Nullable String subsystem,
+                                    @Nullable String phase,
+                                    @Nullable String operation,
+                                    @Nullable String target,
+                                    @Nullable String featureKey,
+                                    @Nullable String entryPoint,
+                                    @Nullable String runtimeSide,
+                                    @Nullable String entityType,
+                                    @Nullable String itemId,
+                                    @Nullable String blockId,
+                                    @Nullable String biomeId,
+                                    @Nullable String commandName,
+                                    @Nullable String worldName,
+                                    @Nonnull Map<String, Object> details) {
+
+    private static final int MAX_DETAIL_FIELDS = 20;
+    private static final TelemetryEventContext EMPTY = builder().build();
+
+    @Nonnull
+    public static TelemetryEventContext empty() {
+        return EMPTY;
+    }
+
+    @Nonnull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Nonnull
+    public static Builder error() {
+        return builder().severity("error");
+    }
+
+    @Nonnull
+    public static Builder lifecycle() {
+        return builder();
+    }
+
+    @Nonnull
+    public static Builder performance() {
+        return builder();
+    }
+
+    @Nonnull
+    public static Builder usage() {
+        return builder();
+    }
+
+    @Nonnull
+    public TelemetryEventContext normalize() {
+        return new TelemetryEventContext(
+                normalizeNullable(detail, 500),
+                normalizeNullable(severity, 32),
+                normalizeNullable(fingerprint, 200),
+                normalizeNullable(subsystem, 120),
+                normalizeNullable(phase, 120),
+                normalizeNullable(operation, 120),
+                normalizeNullable(target, 200),
+                normalizeNullable(featureKey, 120),
+                normalizeNullable(entryPoint, 120),
+                normalizeNullable(runtimeSide, 80),
+                normalizeNullable(entityType, 120),
+                normalizeNullable(itemId, 160),
+                normalizeNullable(blockId, 160),
+                normalizeNullable(biomeId, 160),
+                normalizeNullable(commandName, 120),
+                normalizeNullable(worldName, 200),
+                normalizeDetails(details)
+        );
+    }
+
+    @Nullable
+    private static String normalizeNullable(@Nullable String value, int maxLength) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.length() <= maxLength ? trimmed : trimmed.substring(0, maxLength);
+    }
+
+    @Nonnull
+    private static Map<String, Object> normalizeDetails(@Nullable Map<String, Object> rawDetails) {
+        if (rawDetails == null || rawDetails.isEmpty()) {
+            return Map.of();
+        }
+        LinkedHashMap<String, Object> normalized = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : rawDetails.entrySet()) {
+            if (normalized.size() >= MAX_DETAIL_FIELDS || entry == null) {
+                break;
+            }
+            String key = normalizeNullable(entry.getKey(), 80);
+            Object value = normalizeDetailValue(entry.getValue());
+            if (key != null && value != null) {
+                normalized.put(key, value);
+            }
+        }
+        return Map.copyOf(normalized);
+    }
+
+    @Nullable
+    private static Object normalizeDetailValue(@Nullable Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Boolean || value instanceof Number) {
+            return value;
+        }
+        if (value instanceof CharSequence text) {
+            return normalizeNullable(text.toString(), 500);
+        }
+        return null;
+    }
+
+    public static final class Builder {
+        private final LinkedHashMap<String, Object> details = new LinkedHashMap<>();
+        private String detail;
+        private String severity;
+        private String fingerprint;
+        private String subsystem;
+        private String phase;
+        private String operation;
+        private String target;
+        private String featureKey;
+        private String entryPoint;
+        private String runtimeSide;
+        private String entityType;
+        private String itemId;
+        private String blockId;
+        private String biomeId;
+        private String commandName;
+        private String worldName;
+
+        private Builder() {
+        }
+
+        @Nonnull
+        public Builder detail(@Nullable String detail) {
+            this.detail = detail;
+            return this;
+        }
+
+        @Nonnull
+        public Builder detail(@Nonnull String key, @Nullable Object value) {
+            details.put(key, value);
+            return this;
+        }
+
+        @Nonnull
+        public Builder severity(@Nullable String severity) {
+            this.severity = severity;
+            return this;
+        }
+
+        @Nonnull
+        public Builder fingerprint(@Nullable String fingerprint) {
+            this.fingerprint = fingerprint;
+            return this;
+        }
+
+        @Nonnull
+        public Builder subsystem(@Nullable String subsystem) {
+            this.subsystem = subsystem;
+            return this;
+        }
+
+        @Nonnull
+        public Builder phase(@Nullable String phase) {
+            this.phase = phase;
+            return this;
+        }
+
+        @Nonnull
+        public Builder operation(@Nullable String operation) {
+            this.operation = operation;
+            return this;
+        }
+
+        @Nonnull
+        public Builder target(@Nullable String target) {
+            this.target = target;
+            return this;
+        }
+
+        @Nonnull
+        public Builder featureKey(@Nullable String featureKey) {
+            this.featureKey = featureKey;
+            return this;
+        }
+
+        @Nonnull
+        public Builder entryPoint(@Nullable String entryPoint) {
+            this.entryPoint = entryPoint;
+            return this;
+        }
+
+        @Nonnull
+        public Builder runtimeSide(@Nullable String runtimeSide) {
+            this.runtimeSide = runtimeSide;
+            return this;
+        }
+
+        @Nonnull
+        public Builder entityType(@Nullable String entityType) {
+            this.entityType = entityType;
+            return this;
+        }
+
+        @Nonnull
+        public Builder itemId(@Nullable String itemId) {
+            this.itemId = itemId;
+            return this;
+        }
+
+        @Nonnull
+        public Builder blockId(@Nullable String blockId) {
+            this.blockId = blockId;
+            return this;
+        }
+
+        @Nonnull
+        public Builder biomeId(@Nullable String biomeId) {
+            this.biomeId = biomeId;
+            return this;
+        }
+
+        @Nonnull
+        public Builder commandName(@Nullable String commandName) {
+            this.commandName = commandName;
+            return this;
+        }
+
+        @Nonnull
+        public Builder worldName(@Nullable String worldName) {
+            this.worldName = worldName;
+            return this;
+        }
+
+        @Nonnull
+        public TelemetryEventContext build() {
+            return new TelemetryEventContext(
+                    detail,
+                    severity,
+                    fingerprint,
+                    subsystem,
+                    phase,
+                    operation,
+                    target,
+                    featureKey,
+                    entryPoint,
+                    runtimeSide,
+                    entityType,
+                    itemId,
+                    blockId,
+                    biomeId,
+                    commandName,
+                    worldName,
+                    Map.copyOf(details)
+            ).normalize();
+        }
+    }
+}

--- a/src/main/java/com/alechilles/alecstelemetry/api/TelemetryEventContext.java
+++ b/src/main/java/com/alechilles/alecstelemetry/api/TelemetryEventContext.java
@@ -267,7 +267,7 @@ public record TelemetryEventContext(@Nullable String detail,
                     biomeId,
                     commandName,
                     worldName,
-                    Map.copyOf(details)
+                    new LinkedHashMap<>(details)
             ).normalize();
         }
     }

--- a/src/main/java/com/alechilles/alecstelemetry/core/TelemetryCoreEngine.java
+++ b/src/main/java/com/alechilles/alecstelemetry/core/TelemetryCoreEngine.java
@@ -626,7 +626,7 @@ public final class TelemetryCoreEngine {
 
     private void putBreadcrumbDetails(@Nonnull TelemetryProjectRegistration project,
                                       @Nonnull Map<String, Object> details) {
-        if (!project.events().breadcrumbs().enabled()) {
+        if (!project.events().breadcrumbs().enabled() || !project.events().breadcrumbs().automatic()) {
             return;
         }
         List<CrashReportEnvelope.BreadcrumbEntry> snapshot = breadcrumbs.snapshot(project.projectId());

--- a/src/main/java/com/alechilles/alecstelemetry/core/TelemetryCoreEngine.java
+++ b/src/main/java/com/alechilles/alecstelemetry/core/TelemetryCoreEngine.java
@@ -258,7 +258,7 @@ public final class TelemetryCoreEngine {
         CrashReportEnvelope.RuntimeMetadata runtimeMetadata = CrashReportEnvelope.RuntimeMetadata.capture(loadedMods);
         LinkedHashMap<String, Object> attributes = new LinkedHashMap<>();
         putDetail(attributes, normalizedContext);
-        LinkedHashMap<String, Object> details = new LinkedHashMap<>();
+        LinkedHashMap<String, Object> details = new LinkedHashMap<>(normalizedContext.details());
         if (!success) {
             putBreadcrumbDetails(project, details);
         }

--- a/src/main/java/com/alechilles/alecstelemetry/core/TelemetryCoreEngine.java
+++ b/src/main/java/com/alechilles/alecstelemetry/core/TelemetryCoreEngine.java
@@ -1,5 +1,6 @@
 package com.alechilles.alecstelemetry.core;
 
+import com.alechilles.alecstelemetry.api.TelemetryEventContext;
 import com.alechilles.alecstelemetry.crash.CrashAttribution;
 import com.alechilles.alecstelemetry.crash.CrashReportClient;
 import com.alechilles.alecstelemetry.crash.CrashReportEnvelope;
@@ -156,11 +157,15 @@ public final class TelemetryCoreEngine {
         if (project == null || !project.isEnabled()) {
             return;
         }
+        if (!project.events().breadcrumbs().enabled()) {
+            return;
+        }
         breadcrumbs.record(project.projectId(), category, detail);
     }
 
     public void clearBreadcrumbs(@Nonnull String projectId) {
-        breadcrumbs.clear(projectId);
+        TelemetryProjectRegistration project = findProject(projectId);
+        breadcrumbs.clear(project == null ? projectId : project.projectId());
     }
 
     public void captureSetupFailure(@Nonnull String projectId, @Nullable Throwable throwable) {
@@ -175,22 +180,33 @@ public final class TelemetryCoreEngine {
                             @Nonnull String eventName,
                             @Nullable Throwable throwable,
                             @Nullable String detail) {
+        recordError(projectId, eventName, throwable, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public void recordError(@Nonnull String projectId,
+                            @Nonnull String eventName,
+                            @Nullable Throwable throwable,
+                            @Nullable TelemetryEventContext context) {
         if (!enabled.get()) {
             return;
         }
         TelemetryProjectRegistration project = findProject(projectId);
-        if (project == null || !project.isEnabled() || project.resolveEventDeliveryTarget(settings) == null) {
+        if (project == null
+                || !project.isEnabled()
+                || !project.events().errors().enabled()
+                || project.resolveEventDeliveryTarget(settings) == null) {
             return;
         }
+        TelemetryEventContext normalizedContext = normalizeContext(context);
         CrashReportEnvelope.RuntimeMetadata runtimeMetadata = CrashReportEnvelope.RuntimeMetadata.capture(loadedMods);
         LinkedHashMap<String, Object> attributes = new LinkedHashMap<>();
-        if (detail != null && !detail.isBlank()) {
-            attributes.put("detail", detail.trim());
-        }
+        putDetail(attributes, normalizedContext);
         if (throwable != null) {
             attributes.put("throwableType", throwable.getClass().getName());
             attributes.put("throwableMessage", throwable.getMessage() == null ? "<empty>" : throwable.getMessage());
         }
+        LinkedHashMap<String, Object> details = new LinkedHashMap<>();
+        putBreadcrumbDetails(project, details);
         TelemetryEventEnvelope event = TelemetryEventEnvelope.error(
                 project.projectId(),
                 project.displayName(),
@@ -199,10 +215,12 @@ public final class TelemetryCoreEngine {
                 eventName,
                 project.pluginIdentifier(),
                 project.pluginVersion(),
-                null,
-                throwable == null ? TelemetryEventEnvelope.SEVERITY_WARNING : TelemetryEventEnvelope.SEVERITY_ERROR,
+                normalizedContext.worldName(),
+                severityOrDefault(normalizedContext, throwable == null ? TelemetryEventEnvelope.SEVERITY_WARNING : TelemetryEventEnvelope.SEVERITY_ERROR),
                 environmentFor(project, runtimeMetadata),
                 attributes,
+                details,
+                normalizedContext,
                 runtimeMetadata
         );
         if (!eventStoreFor(project).persist(event)) {
@@ -217,17 +235,31 @@ public final class TelemetryCoreEngine {
                                 int durationMs,
                                 boolean success,
                                 @Nullable String detail) {
+        recordLifecycle(projectId, eventName, durationMs, success, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public void recordLifecycle(@Nonnull String projectId,
+                                @Nonnull String eventName,
+                                int durationMs,
+                                boolean success,
+                                @Nullable TelemetryEventContext context) {
         if (!enabled.get()) {
             return;
         }
         TelemetryProjectRegistration project = findProject(projectId);
-        if (project == null || !project.isEnabled() || project.resolveEventDeliveryTarget(settings) == null) {
+        if (project == null
+                || !project.isEnabled()
+                || !project.events().lifecycle().enabled()
+                || project.resolveEventDeliveryTarget(settings) == null) {
             return;
         }
+        TelemetryEventContext normalizedContext = normalizeContext(context);
         CrashReportEnvelope.RuntimeMetadata runtimeMetadata = CrashReportEnvelope.RuntimeMetadata.capture(loadedMods);
         LinkedHashMap<String, Object> attributes = new LinkedHashMap<>();
-        if (detail != null && !detail.isBlank()) {
-            attributes.put("detail", detail.trim());
+        putDetail(attributes, normalizedContext);
+        LinkedHashMap<String, Object> details = new LinkedHashMap<>();
+        if (!success) {
+            putBreadcrumbDetails(project, details);
         }
         TelemetryEventEnvelope event = TelemetryEventEnvelope.lifecycle(
                 project.projectId(),
@@ -237,11 +269,13 @@ public final class TelemetryCoreEngine {
                 eventName,
                 project.pluginIdentifier(),
                 project.pluginVersion(),
-                null,
+                normalizedContext.worldName(),
                 success,
                 durationMs,
                 environmentFor(project, runtimeMetadata),
                 attributes,
+                details,
+                normalizedContext,
                 runtimeMetadata
         );
         if (!eventStoreFor(project).persist(event)) {
@@ -256,6 +290,14 @@ public final class TelemetryCoreEngine {
                                   int durationMs,
                                   @Nullable Double metricValue,
                                   @Nullable String detail) {
+        recordPerformance(projectId, eventName, durationMs, metricValue, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public void recordPerformance(@Nonnull String projectId,
+                                  @Nonnull String eventName,
+                                  int durationMs,
+                                  @Nullable Double metricValue,
+                                  @Nullable TelemetryEventContext context) {
         if (!enabled.get()) {
             return;
         }
@@ -269,12 +311,12 @@ public final class TelemetryCoreEngine {
         if (project.performance().sampleRate() < 1.0d && ThreadLocalRandom.current().nextDouble() > project.performance().sampleRate()) {
             return;
         }
+        TelemetryEventContext normalizedContext = normalizeContext(context);
         CrashReportEnvelope.RuntimeMetadata runtimeMetadata = CrashReportEnvelope.RuntimeMetadata.capture(loadedMods);
         LinkedHashMap<String, Object> attributes = new LinkedHashMap<>();
-        if (detail != null && !detail.isBlank()) {
-            attributes.put("detail", detail.trim());
-        }
+        putDetail(attributes, normalizedContext);
         attributes.put("thresholdMs", project.performance().thresholdMs());
+        Map<String, Object> details = project.performance().sanitizeDetails(eventName, normalizedContext.details());
         TelemetryEventEnvelope event = TelemetryEventEnvelope.performance(
                 project.projectId(),
                 project.displayName(),
@@ -283,11 +325,13 @@ public final class TelemetryCoreEngine {
                 eventName,
                 project.pluginIdentifier(),
                 project.pluginVersion(),
-                null,
+                normalizedContext.worldName(),
                 durationMs,
                 metricValue,
                 environmentFor(project, runtimeMetadata),
                 attributes,
+                details,
+                normalizedContext,
                 runtimeMetadata
         );
         if (!eventStoreFor(project).persist(event)) {
@@ -300,6 +344,12 @@ public final class TelemetryCoreEngine {
     public void recordUsage(@Nonnull String projectId,
                             @Nonnull String eventName,
                             @Nullable String detail) {
+        recordUsage(projectId, eventName, TelemetryEventContext.builder().detail(detail).build());
+    }
+
+    public void recordUsage(@Nonnull String projectId,
+                            @Nonnull String eventName,
+                            @Nullable TelemetryEventContext context) {
         if (!enabled.get()) {
             return;
         }
@@ -310,11 +360,11 @@ public final class TelemetryCoreEngine {
         if (!project.usage().allows(eventName)) {
             return;
         }
+        TelemetryEventContext normalizedContext = normalizeContext(context);
         CrashReportEnvelope.RuntimeMetadata runtimeMetadata = CrashReportEnvelope.RuntimeMetadata.capture(loadedMods);
         LinkedHashMap<String, Object> attributes = new LinkedHashMap<>();
-        if (detail != null && !detail.isBlank()) {
-            attributes.put("detail", detail.trim());
-        }
+        putDetail(attributes, normalizedContext);
+        Map<String, Object> details = project.usage().sanitizeDetails(eventName, normalizedContext.details());
         TelemetryEventEnvelope event = TelemetryEventEnvelope.usage(
                 project.projectId(),
                 project.displayName(),
@@ -323,9 +373,11 @@ public final class TelemetryCoreEngine {
                 eventName,
                 project.pluginIdentifier(),
                 project.pluginVersion(),
-                null,
+                normalizedContext.worldName(),
                 environmentFor(project, runtimeMetadata),
                 attributes,
+                details,
+                normalizedContext,
                 runtimeMetadata
         );
         if (!eventStoreFor(project).persist(event)) {
@@ -558,6 +610,35 @@ public final class TelemetryCoreEngine {
         if (result == CrashReportStore.WriteResult.FAILED) {
             logWarning("Failed to store crash telemetry report for project " + project.projectId() + ".", null);
         }
+    }
+
+    @Nonnull
+    private static TelemetryEventContext normalizeContext(@Nullable TelemetryEventContext context) {
+        return context == null ? TelemetryEventContext.empty() : context.normalize();
+    }
+
+    private static void putDetail(@Nonnull Map<String, Object> attributes,
+                                  @Nonnull TelemetryEventContext context) {
+        if (context.detail() != null && !context.detail().isBlank()) {
+            attributes.put("detail", context.detail().trim());
+        }
+    }
+
+    private void putBreadcrumbDetails(@Nonnull TelemetryProjectRegistration project,
+                                      @Nonnull Map<String, Object> details) {
+        if (!project.events().breadcrumbs().enabled()) {
+            return;
+        }
+        List<CrashReportEnvelope.BreadcrumbEntry> snapshot = breadcrumbs.snapshot(project.projectId());
+        if (!snapshot.isEmpty()) {
+            details.put("breadcrumbs", snapshot);
+        }
+    }
+
+    @Nonnull
+    private static String severityOrDefault(@Nonnull TelemetryEventContext context,
+                                            @Nonnull String fallback) {
+        return context.severity() == null || context.severity().isBlank() ? fallback : context.severity();
     }
 
     @Nonnull

--- a/src/main/java/com/alechilles/alecstelemetry/core/TelemetryCoreEngine.java
+++ b/src/main/java/com/alechilles/alecstelemetry/core/TelemetryCoreEngine.java
@@ -176,26 +176,26 @@ public final class TelemetryCoreEngine {
         captureExplicitProject(projectId, SOURCE_START_FAILURE, throwable);
     }
 
-    public void recordError(@Nonnull String projectId,
-                            @Nonnull String eventName,
-                            @Nullable Throwable throwable,
-                            @Nullable String detail) {
-        recordError(projectId, eventName, throwable, TelemetryEventContext.builder().detail(detail).build());
+    public boolean recordError(@Nonnull String projectId,
+                               @Nonnull String eventName,
+                               @Nullable Throwable throwable,
+                               @Nullable String detail) {
+        return recordError(projectId, eventName, throwable, TelemetryEventContext.builder().detail(detail).build());
     }
 
-    public void recordError(@Nonnull String projectId,
-                            @Nonnull String eventName,
-                            @Nullable Throwable throwable,
-                            @Nullable TelemetryEventContext context) {
+    public boolean recordError(@Nonnull String projectId,
+                               @Nonnull String eventName,
+                               @Nullable Throwable throwable,
+                               @Nullable TelemetryEventContext context) {
         if (!enabled.get()) {
-            return;
+            return false;
         }
         TelemetryProjectRegistration project = findProject(projectId);
         if (project == null
                 || !project.isEnabled()
                 || !project.events().errors().enabled()
                 || project.resolveEventDeliveryTarget(settings) == null) {
-            return;
+            return false;
         }
         TelemetryEventContext normalizedContext = normalizeContext(context);
         CrashReportEnvelope.RuntimeMetadata runtimeMetadata = CrashReportEnvelope.RuntimeMetadata.capture(loadedMods);
@@ -205,7 +205,7 @@ public final class TelemetryCoreEngine {
             attributes.put("throwableType", throwable.getClass().getName());
             attributes.put("throwableMessage", throwable.getMessage() == null ? "<empty>" : throwable.getMessage());
         }
-        LinkedHashMap<String, Object> details = new LinkedHashMap<>();
+        LinkedHashMap<String, Object> details = new LinkedHashMap<>(normalizedContext.details());
         putBreadcrumbDetails(project, details);
         TelemetryEventEnvelope event = TelemetryEventEnvelope.error(
                 project.projectId(),
@@ -225,33 +225,34 @@ public final class TelemetryCoreEngine {
         );
         if (!eventStoreFor(project).persist(event)) {
             logWarning("Failed to store telemetry error event for project " + project.projectId() + ".", null);
-            return;
+            return false;
         }
         requestFlushAsync("event", project.projectId());
+        return true;
     }
 
-    public void recordLifecycle(@Nonnull String projectId,
-                                @Nonnull String eventName,
-                                int durationMs,
-                                boolean success,
-                                @Nullable String detail) {
-        recordLifecycle(projectId, eventName, durationMs, success, TelemetryEventContext.builder().detail(detail).build());
+    public boolean recordLifecycle(@Nonnull String projectId,
+                                   @Nonnull String eventName,
+                                   int durationMs,
+                                   boolean success,
+                                   @Nullable String detail) {
+        return recordLifecycle(projectId, eventName, durationMs, success, TelemetryEventContext.builder().detail(detail).build());
     }
 
-    public void recordLifecycle(@Nonnull String projectId,
-                                @Nonnull String eventName,
-                                int durationMs,
-                                boolean success,
-                                @Nullable TelemetryEventContext context) {
+    public boolean recordLifecycle(@Nonnull String projectId,
+                                   @Nonnull String eventName,
+                                   int durationMs,
+                                   boolean success,
+                                   @Nullable TelemetryEventContext context) {
         if (!enabled.get()) {
-            return;
+            return false;
         }
         TelemetryProjectRegistration project = findProject(projectId);
         if (project == null
                 || !project.isEnabled()
                 || !project.events().lifecycle().enabled()
                 || project.resolveEventDeliveryTarget(settings) == null) {
-            return;
+            return false;
         }
         TelemetryEventContext normalizedContext = normalizeContext(context);
         CrashReportEnvelope.RuntimeMetadata runtimeMetadata = CrashReportEnvelope.RuntimeMetadata.capture(loadedMods);
@@ -280,9 +281,10 @@ public final class TelemetryCoreEngine {
         );
         if (!eventStoreFor(project).persist(event)) {
             logWarning("Failed to store telemetry lifecycle event for project " + project.projectId() + ".", null);
-            return;
+            return false;
         }
         requestFlushAsync("event", project.projectId());
+        return true;
     }
 
     public void recordPerformance(@Nonnull String projectId,

--- a/src/main/java/com/alechilles/alecstelemetry/event/TelemetryEventEnvelope.java
+++ b/src/main/java/com/alechilles/alecstelemetry/event/TelemetryEventEnvelope.java
@@ -1,5 +1,6 @@
 package com.alechilles.alecstelemetry.event;
 
+import com.alechilles.alecstelemetry.api.TelemetryEventContext;
 import com.alechilles.alecstelemetry.crash.CrashReportEnvelope;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -22,6 +23,7 @@ public record TelemetryEventEnvelope(int schemaVersion,
                                      @Nonnull String projectDisplayName,
                                      @Nonnull String source,
                                      @Nonnull String sessionId,
+                                     @Nullable String fingerprint,
                                      @Nonnull String capturedAtUtc,
                                      @Nonnull String pluginIdentifier,
                                      @Nonnull String pluginVersion,
@@ -29,8 +31,21 @@ public record TelemetryEventEnvelope(int schemaVersion,
                                      @Nonnull String severity,
                                      @Nullable Integer durationMs,
                                      @Nullable Double metricValue,
+                                     @Nullable String subsystem,
+                                     @Nullable String phase,
+                                     @Nullable String operation,
+                                     @Nullable String target,
+                                     @Nullable String featureKey,
+                                     @Nullable String entryPoint,
+                                     @Nullable String runtimeSide,
+                                     @Nullable String entityType,
+                                     @Nullable String itemId,
+                                     @Nullable String blockId,
+                                     @Nullable String biomeId,
+                                     @Nullable String commandName,
                                      @Nullable CrashReportEnvelope.EnvironmentSnapshot environment,
                                      @Nonnull Map<String, Object> attributes,
+                                     @Nonnull Map<String, Object> details,
                                      @Nonnull CrashReportEnvelope.RuntimeMetadata runtime) {
 
     private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
@@ -56,6 +71,8 @@ public record TelemetryEventEnvelope(int schemaVersion,
                                                @Nonnull String severity,
                                                @Nonnull CrashReportEnvelope.EnvironmentSnapshot environment,
                                                @Nonnull Map<String, Object> attributes,
+                                               @Nonnull Map<String, Object> details,
+                                               @Nonnull TelemetryEventContext context,
                                                @Nonnull CrashReportEnvelope.RuntimeMetadata runtime) {
         return create(
                 TYPE_ERROR,
@@ -72,6 +89,8 @@ public record TelemetryEventEnvelope(int schemaVersion,
                 null,
                 environment,
                 attributes,
+                details,
+                context,
                 runtime
         );
     }
@@ -89,6 +108,8 @@ public record TelemetryEventEnvelope(int schemaVersion,
                                                    int durationMs,
                                                    @Nonnull CrashReportEnvelope.EnvironmentSnapshot environment,
                                                    @Nonnull Map<String, Object> attributes,
+                                                   @Nonnull Map<String, Object> details,
+                                                   @Nonnull TelemetryEventContext context,
                                                    @Nonnull CrashReportEnvelope.RuntimeMetadata runtime) {
         LinkedHashMap<String, Object> withSuccess = new LinkedHashMap<>(attributes);
         withSuccess.putIfAbsent("success", success);
@@ -107,6 +128,8 @@ public record TelemetryEventEnvelope(int schemaVersion,
                 null,
                 environment,
                 withSuccess,
+                details,
+                context,
                 runtime
         );
     }
@@ -124,6 +147,8 @@ public record TelemetryEventEnvelope(int schemaVersion,
                                                      @Nullable Double metricValue,
                                                      @Nonnull CrashReportEnvelope.EnvironmentSnapshot environment,
                                                      @Nonnull Map<String, Object> attributes,
+                                                     @Nonnull Map<String, Object> details,
+                                                     @Nonnull TelemetryEventContext context,
                                                      @Nonnull CrashReportEnvelope.RuntimeMetadata runtime) {
         return create(
                 TYPE_PERFORMANCE,
@@ -140,6 +165,8 @@ public record TelemetryEventEnvelope(int schemaVersion,
                 metricValue,
                 environment,
                 attributes,
+                details,
+                context,
                 runtime
         );
     }
@@ -155,6 +182,8 @@ public record TelemetryEventEnvelope(int schemaVersion,
                                                @Nullable String worldName,
                                                @Nonnull CrashReportEnvelope.EnvironmentSnapshot environment,
                                                @Nonnull Map<String, Object> attributes,
+                                               @Nonnull Map<String, Object> details,
+                                               @Nonnull TelemetryEventContext context,
                                                @Nonnull CrashReportEnvelope.RuntimeMetadata runtime) {
         return create(
                 TYPE_USAGE,
@@ -171,6 +200,8 @@ public record TelemetryEventEnvelope(int schemaVersion,
                 null,
                 environment,
                 attributes,
+                details,
+                context,
                 runtime
         );
     }
@@ -201,7 +232,10 @@ public record TelemetryEventEnvelope(int schemaVersion,
                                                  @Nullable Double metricValue,
                                                  @Nonnull CrashReportEnvelope.EnvironmentSnapshot environment,
                                                  @Nonnull Map<String, Object> attributes,
+                                                 @Nonnull Map<String, Object> details,
+                                                 @Nonnull TelemetryEventContext context,
                                                  @Nonnull CrashReportEnvelope.RuntimeMetadata runtime) {
+        TelemetryEventContext normalizedContext = context.normalize();
         return new TelemetryEventEnvelope(
                 SCHEMA_VERSION,
                 normalizeType(eventType),
@@ -211,6 +245,7 @@ public record TelemetryEventEnvelope(int schemaVersion,
                 normalizeNonBlank(projectDisplayName, projectId),
                 normalizeNonBlank(source, "runtime"),
                 normalizeNonBlank(sessionId, UUID.randomUUID().toString()),
+                normalizeNullable(normalizedContext.fingerprint()),
                 Instant.now().toString(),
                 normalizeNonBlank(pluginIdentifier, "unknown"),
                 normalizeNonBlank(pluginVersion, "unknown"),
@@ -218,8 +253,21 @@ public record TelemetryEventEnvelope(int schemaVersion,
                 normalizeSeverity(severity),
                 durationMs == null ? null : Math.max(0, durationMs),
                 metricValue,
+                normalizeNullable(normalizedContext.subsystem()),
+                normalizeNullable(normalizedContext.phase()),
+                normalizeNullable(normalizedContext.operation()),
+                normalizeNullable(normalizedContext.target()),
+                normalizeNullable(normalizedContext.featureKey()),
+                normalizeNullable(normalizedContext.entryPoint()),
+                normalizeNullable(normalizedContext.runtimeSide()),
+                normalizeNullable(normalizedContext.entityType()),
+                normalizeNullable(normalizedContext.itemId()),
+                normalizeNullable(normalizedContext.blockId()),
+                normalizeNullable(normalizedContext.biomeId()),
+                normalizeNullable(normalizedContext.commandName()),
                 environment.normalize(),
-                normalizeAttributes(attributes),
+                normalizeObjectMap(attributes),
+                normalizeObjectMap(details),
                 runtime.normalize()
         );
     }
@@ -235,6 +283,7 @@ public record TelemetryEventEnvelope(int schemaVersion,
                 normalizeNonBlank(projectDisplayName(), projectId()),
                 normalizeNonBlank(source(), "runtime"),
                 normalizeNonBlank(sessionId(), UUID.randomUUID().toString()),
+                normalizeNullable(fingerprint()),
                 normalizeNonBlank(capturedAtUtc(), Instant.now().toString()),
                 normalizeNonBlank(pluginIdentifier(), "unknown"),
                 normalizeNonBlank(pluginVersion(), "unknown"),
@@ -242,8 +291,21 @@ public record TelemetryEventEnvelope(int schemaVersion,
                 normalizeSeverity(severity()),
                 durationMs() == null ? null : Math.max(0, durationMs()),
                 metricValue(),
+                normalizeNullable(subsystem()),
+                normalizeNullable(phase()),
+                normalizeNullable(operation()),
+                normalizeNullable(target()),
+                normalizeNullable(featureKey()),
+                normalizeNullable(entryPoint()),
+                normalizeNullable(runtimeSide()),
+                normalizeNullable(entityType()),
+                normalizeNullable(itemId()),
+                normalizeNullable(blockId()),
+                normalizeNullable(biomeId()),
+                normalizeNullable(commandName()),
                 environment() == null ? new CrashReportEnvelope.EnvironmentSnapshot("unknown", "unknown", "unknown") : environment().normalize(),
-                normalizeAttributes(attributes()),
+                normalizeObjectMap(attributes()),
+                normalizeObjectMap(details()),
                 runtime() == null ? CrashReportEnvelope.RuntimeMetadata.capture(java.util.List.of()) : runtime().normalize()
         );
     }
@@ -265,17 +327,19 @@ public record TelemetryEventEnvelope(int schemaVersion,
                 null,
                 new CrashReportEnvelope.EnvironmentSnapshot("unknown", "unknown", "unknown"),
                 Map.of(),
+                Map.of(),
+                TelemetryEventContext.empty(),
                 CrashReportEnvelope.RuntimeMetadata.capture(java.util.List.of())
         );
     }
 
     @Nonnull
-    private static Map<String, Object> normalizeAttributes(@Nullable Map<String, Object> attributes) {
-        if (attributes == null || attributes.isEmpty()) {
+    private static Map<String, Object> normalizeObjectMap(@Nullable Map<String, Object> values) {
+        if (values == null || values.isEmpty()) {
             return Map.of();
         }
         LinkedHashMap<String, Object> normalized = new LinkedHashMap<>();
-        for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+        for (Map.Entry<String, Object> entry : values.entrySet()) {
             if (entry == null || entry.getKey() == null || entry.getKey().isBlank() || entry.getValue() == null) {
                 continue;
             }

--- a/src/main/java/com/alechilles/alecstelemetry/project/TelemetryProjectDescriptor.java
+++ b/src/main/java/com/alechilles/alecstelemetry/project/TelemetryProjectDescriptor.java
@@ -21,13 +21,14 @@ public record TelemetryProjectDescriptor(int schemaVersion,
                                          @Nonnull String displayName,
                                          @Nonnull String runtimeMode,
                                          @Nonnull List<String> ownerPluginIdentifiers,
-                                          @Nonnull List<String> packagePrefixes,
-                                          @Nonnull CaptureOptions capture,
-                                          @Nonnull PerformanceOptions performance,
-                                          @Nonnull UsageOptions usage,
-                                          @Nonnull Defaults defaults,
-                                          @Nonnull HostedDestination hosted,
-                                          @Nonnull CustomEndpoint customEndpoint) {
+                                         @Nonnull List<String> packagePrefixes,
+                                         @Nonnull CaptureOptions capture,
+                                         @Nonnull EventOptions events,
+                                         @Nonnull PerformanceOptions performance,
+                                         @Nonnull UsageOptions usage,
+                                         @Nonnull Defaults defaults,
+                                         @Nonnull HostedDestination hosted,
+                                         @Nonnull CustomEndpoint customEndpoint) {
 
     private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
     private static final int CURRENT_SCHEMA_VERSION = 1;
@@ -75,18 +76,33 @@ public record TelemetryProjectDescriptor(int schemaVersion,
         );
 
         PerformanceOptions performance = safe.performance == null
-                ? new PerformanceOptions(false, 1.0d, 100)
+                ? new PerformanceOptions(false, 1.0d, 100, Map.of())
                 : new PerformanceOptions(
                 boolOrDefault(safe.performance.enabled, false),
                 doubleOrDefault(safe.performance.sampleRate, 1.0d, 0.0d, 1.0d),
-                intOrDefault(safe.performance.thresholdMs, 100, 1, 60000)
+                intOrDefault(safe.performance.thresholdMs, 100, 1, 60000),
+                normalizeDetailRules(safe.performance.details)
         );
 
         UsageOptions usage = safe.usage == null
-                ? new UsageOptions(false, List.of())
+                ? new UsageOptions(false, List.of(), Map.of())
                 : new UsageOptions(
                 boolOrDefault(safe.usage.enabled, false),
-                normalizeNonBlankList(safe.usage.allowedEvents, 120)
+                normalizeNonBlankList(safe.usage.allowedEvents, 120),
+                normalizeDetailRules(safe.usage.details)
+        );
+
+        EventOptions events = safe.events == null
+                ? EventOptions.defaults()
+                : new EventOptions(
+                new EventTypeOptions(safe.events.errors == null || boolOrDefault(safe.events.errors.enabled, true)),
+                new EventTypeOptions(safe.events.lifecycle == null || boolOrDefault(safe.events.lifecycle.enabled, true)),
+                safe.events.breadcrumbs == null
+                        ? new BreadcrumbOptions(true, true)
+                        : new BreadcrumbOptions(
+                        boolOrDefault(safe.events.breadcrumbs.enabled, true),
+                        boolOrDefault(safe.events.breadcrumbs.automatic, true)
+                )
         );
 
         HostedDestination hosted = new HostedDestination(
@@ -114,6 +130,7 @@ public record TelemetryProjectDescriptor(int schemaVersion,
                 ownerPluginIdentifiers,
                 packagePrefixes,
                 capture,
+                events,
                 performance,
                 usage,
                 defaults,
@@ -229,12 +246,146 @@ public record TelemetryProjectDescriptor(int schemaVersion,
         return Map.copyOf(normalized);
     }
 
+    @Nonnull
+    private static Map<String, DetailRules> normalizeDetailRules(@Nullable Map<String, DetailRulesDocument> documents) {
+        if (documents == null || documents.isEmpty()) {
+            return Map.of();
+        }
+        LinkedHashMap<String, DetailRules> normalized = new LinkedHashMap<>();
+        for (Map.Entry<String, DetailRulesDocument> entry : documents.entrySet()) {
+            if (entry == null) {
+                continue;
+            }
+            String eventName = normalizeNullable(entry.getKey());
+            DetailRules rules = normalizeDetailRule(entry.getValue());
+            if (eventName != null && !rules.allowedFields().isEmpty()) {
+                normalized.putIfAbsent(eventName.toLowerCase(Locale.ROOT), rules);
+            }
+        }
+        return Map.copyOf(normalized);
+    }
+
+    @Nonnull
+    private static DetailRules normalizeDetailRule(@Nullable DetailRulesDocument document) {
+        if (document == null || document.allowedFields == null || document.allowedFields.isEmpty()) {
+            return new DetailRules(Map.of());
+        }
+        LinkedHashMap<String, DetailFieldRule> fields = new LinkedHashMap<>();
+        for (Map.Entry<String, DetailFieldDocument> entry : document.allowedFields.entrySet()) {
+            if (fields.size() >= 20 || entry == null) {
+                break;
+            }
+            String key = normalizeNullable(entry.getKey());
+            DetailFieldRule field = normalizeDetailField(entry.getValue());
+            if (key != null && field != null) {
+                fields.putIfAbsent(key, field);
+            }
+        }
+        return new DetailRules(Map.copyOf(fields));
+    }
+
+    @Nullable
+    private static DetailFieldRule normalizeDetailField(@Nullable DetailFieldDocument document) {
+        if (document == null) {
+            return null;
+        }
+        String type = normalizeNullable(document.type);
+        if (type == null) {
+            return null;
+        }
+        String normalizedType = type.toLowerCase(Locale.ROOT);
+        if (!"string".equals(normalizedType)
+                && !"number".equals(normalizedType)
+                && !"boolean".equals(normalizedType)
+                && !"enum".equals(normalizedType)) {
+            return null;
+        }
+        List<String> values = "enum".equals(normalizedType)
+                ? normalizeNonBlankList(document.values, 120)
+                : List.of();
+        if ("enum".equals(normalizedType) && values.isEmpty()) {
+            return null;
+        }
+        return new DetailFieldRule(
+                normalizedType,
+                values,
+                intOrDefault(document.maxLength, 120, 1, 500)
+        );
+    }
+
     @Nullable
     private static String normalizeNullable(@Nullable String value) {
         if (value == null || value.isBlank()) {
             return null;
         }
         return value.trim();
+    }
+
+    @Nonnull
+    private static Map<String, Object> sanitizeDetailMap(@Nonnull Map<String, DetailRules> rulesByEventName,
+                                                         @Nonnull String eventName,
+                                                         @Nullable Map<String, Object> rawDetails) {
+        if (rulesByEventName.isEmpty() || rawDetails == null || rawDetails.isEmpty()) {
+            return Map.of();
+        }
+        String normalizedEventName = normalizeNullable(eventName);
+        if (normalizedEventName == null) {
+            return Map.of();
+        }
+        DetailRules rules = rulesByEventName.get(normalizedEventName.toLowerCase(Locale.ROOT));
+        if (rules == null || rules.allowedFields().isEmpty()) {
+            return Map.of();
+        }
+        LinkedHashMap<String, Object> sanitized = new LinkedHashMap<>();
+        for (Map.Entry<String, DetailFieldRule> field : rules.allowedFields().entrySet()) {
+            if (sanitized.size() >= 20) {
+                break;
+            }
+            Object value = sanitizeDetailValue(field.getValue(), rawDetails.get(field.getKey()));
+            if (value != null) {
+                sanitized.put(field.getKey(), value);
+            }
+        }
+        return Map.copyOf(sanitized);
+    }
+
+    @Nullable
+    private static Object sanitizeDetailValue(@Nonnull DetailFieldRule rule, @Nullable Object rawValue) {
+        if (rawValue == null) {
+            return null;
+        }
+        return switch (rule.type()) {
+            case "number" -> rawValue instanceof Number ? rawValue : null;
+            case "boolean" -> rawValue instanceof Boolean ? rawValue : null;
+            case "enum" -> sanitizeEnumValue(rule, rawValue);
+            default -> sanitizeStringValue(rule, rawValue);
+        };
+    }
+
+    @Nullable
+    private static String sanitizeStringValue(@Nonnull DetailFieldRule rule, @Nonnull Object rawValue) {
+        if (!(rawValue instanceof CharSequence text)) {
+            return null;
+        }
+        String normalized = normalizeNullable(text.toString());
+        if (normalized == null) {
+            return null;
+        }
+        return normalized.length() <= rule.maxLength() ? normalized : normalized.substring(0, rule.maxLength());
+    }
+
+    @Nullable
+    private static String sanitizeEnumValue(@Nonnull DetailFieldRule rule, @Nonnull Object rawValue) {
+        String normalized = sanitizeStringValue(rule, rawValue);
+        if (normalized == null) {
+            return null;
+        }
+        for (String allowed : rule.values()) {
+            if (allowed.equalsIgnoreCase(normalized)) {
+                return allowed;
+            }
+        }
+        return null;
     }
 
     @Nonnull
@@ -307,23 +458,66 @@ public record TelemetryProjectDescriptor(int schemaVersion,
     }
 
     /**
+     * Explicit controls for generic telemetry events.
+     */
+    public record EventOptions(@Nonnull EventTypeOptions errors,
+                               @Nonnull EventTypeOptions lifecycle,
+                               @Nonnull BreadcrumbOptions breadcrumbs) {
+
+        @Nonnull
+        public static EventOptions defaults() {
+            return new EventOptions(
+                    new EventTypeOptions(true),
+                    new EventTypeOptions(true),
+                    new BreadcrumbOptions(true, true)
+            );
+        }
+    }
+
+    public record EventTypeOptions(boolean enabled) {
+    }
+
+    public record BreadcrumbOptions(boolean enabled, boolean automatic) {
+    }
+
+    /**
      * Performance telemetry defaults for one project.
      */
     public record PerformanceOptions(boolean enabled,
                                      double sampleRate,
-                                     int thresholdMs) {
+                                     int thresholdMs,
+                                     @Nonnull Map<String, DetailRules> details) {
+
+        @Nonnull
+        public Map<String, Object> sanitizeDetails(@Nonnull String eventName, @Nullable Map<String, Object> rawDetails) {
+            return sanitizeDetailMap(details, eventName, rawDetails);
+        }
     }
 
     /**
      * Usage telemetry defaults and allowlist for one project.
      */
     public record UsageOptions(boolean enabled,
-                               @Nonnull List<String> allowedEvents) {
+                               @Nonnull List<String> allowedEvents,
+                               @Nonnull Map<String, DetailRules> details) {
 
         public boolean allows(@Nonnull String eventName) {
             String normalized = normalizeNullable(eventName);
             return enabled() && normalized != null && allowedEvents().stream().anyMatch(normalized::equalsIgnoreCase);
         }
+
+        @Nonnull
+        public Map<String, Object> sanitizeDetails(@Nonnull String eventName, @Nullable Map<String, Object> rawDetails) {
+            return sanitizeDetailMap(details, eventName, rawDetails);
+        }
+    }
+
+    public record DetailRules(@Nonnull Map<String, DetailFieldRule> allowedFields) {
+    }
+
+    public record DetailFieldRule(@Nonnull String type,
+                                  @Nonnull List<String> values,
+                                  int maxLength) {
     }
 
     /**
@@ -340,7 +534,7 @@ public record TelemetryProjectDescriptor(int schemaVersion,
      */
     public record CustomEndpoint(@Nullable String url,
                                  @Nullable String eventUrl,
-                                  @Nonnull Map<String, String> headers) {
+                                 @Nonnull Map<String, String> headers) {
     }
 
     /**
@@ -360,6 +554,7 @@ public record TelemetryProjectDescriptor(int schemaVersion,
         private List<String> ownerPluginIdentifiers;
         private List<String> packagePrefixes;
         private CaptureDocument capture;
+        private EventsDocument events;
         private PerformanceDocument performance;
         private UsageDocument usage;
         private DefaultsDocument defaults;
@@ -379,15 +574,42 @@ public record TelemetryProjectDescriptor(int schemaVersion,
         private String destinationMode;
     }
 
+    private static final class EventsDocument {
+        private EventTypeDocument errors;
+        private EventTypeDocument lifecycle;
+        private BreadcrumbsDocument breadcrumbs;
+    }
+
+    private static final class EventTypeDocument {
+        private Boolean enabled;
+    }
+
+    private static final class BreadcrumbsDocument {
+        private Boolean enabled;
+        private Boolean automatic;
+    }
+
     private static final class PerformanceDocument {
         private Boolean enabled;
         private Double sampleRate;
         private Integer thresholdMs;
+        private Map<String, DetailRulesDocument> details;
     }
 
     private static final class UsageDocument {
         private Boolean enabled;
         private List<String> allowedEvents;
+        private Map<String, DetailRulesDocument> details;
+    }
+
+    private static final class DetailRulesDocument {
+        private Map<String, DetailFieldDocument> allowedFields;
+    }
+
+    private static final class DetailFieldDocument {
+        private String type;
+        private List<String> values;
+        private Integer maxLength;
     }
 
     private static final class HostedDocument {

--- a/src/main/java/com/alechilles/alecstelemetry/project/TelemetryProjectRegistration.java
+++ b/src/main/java/com/alechilles/alecstelemetry/project/TelemetryProjectRegistration.java
@@ -80,6 +80,11 @@ public record TelemetryProjectRegistration(@Nonnull TelemetryProjectDescriptor d
     }
 
     @Nonnull
+    public TelemetryProjectDescriptor.EventOptions events() {
+        return descriptor.events();
+    }
+
+    @Nonnull
     public TelemetryProjectDescriptor.PerformanceOptions performance() {
         if (override == null || override.performance() == null) {
             return descriptor.performance();
@@ -89,7 +94,8 @@ public record TelemetryProjectRegistration(@Nonnull TelemetryProjectDescriptor d
         return new TelemetryProjectDescriptor.PerformanceOptions(
                 performanceOverride.enabled() == null ? defaults.enabled() : performanceOverride.enabled(),
                 performanceOverride.sampleRate() == null ? defaults.sampleRate() : performanceOverride.sampleRate(),
-                performanceOverride.thresholdMs() == null ? defaults.thresholdMs() : performanceOverride.thresholdMs()
+                performanceOverride.thresholdMs() == null ? defaults.thresholdMs() : performanceOverride.thresholdMs(),
+                defaults.details()
         );
     }
 
@@ -102,7 +108,8 @@ public record TelemetryProjectRegistration(@Nonnull TelemetryProjectDescriptor d
         TelemetryProjectOverride.UsageOverride usageOverride = override.usage();
         return new TelemetryProjectDescriptor.UsageOptions(
                 usageOverride.enabled() == null ? defaults.enabled() : usageOverride.enabled(),
-                usageOverride.allowedEvents().isEmpty() ? defaults.allowedEvents() : usageOverride.allowedEvents()
+                usageOverride.allowedEvents().isEmpty() ? defaults.allowedEvents() : usageOverride.allowedEvents(),
+                defaults.details()
         );
     }
 

--- a/src/main/resources/telemetry/project.json
+++ b/src/main/resources/telemetry/project.json
@@ -3,10 +3,66 @@
   "projectId": "alecs-tamework",
   "displayName": "Alec's Tamework!",
   "runtimeMode": "embedded",
+  "events": {
+    "errors": {
+      "enabled": true
+    },
+    "lifecycle": {
+      "enabled": true
+    },
+    "breadcrumbs": {
+      "enabled": true,
+      "automatic": true
+    }
+  },
   "performance": {
     "enabled": true,
     "sampleRate": 1.0,
-    "thresholdMs": 100
+    "thresholdMs": 100,
+    "details": {
+      "plugin_setup_duration": {
+        "allowedFields": {
+          "result": {
+            "type": "enum",
+            "values": ["failed"]
+          }
+        }
+      },
+      "plugin_start_duration": {
+        "allowedFields": {
+          "result": {
+            "type": "enum",
+            "values": ["failed"]
+          }
+        }
+      },
+      "reload_config_duration": {
+        "allowedFields": {
+          "result": {
+            "type": "enum",
+            "values": ["success", "failed", "partial"]
+          },
+          "itemConfigCount": {
+            "type": "number"
+          },
+          "totalSpawners": {
+            "type": "number"
+          },
+          "totalNaming": {
+            "type": "number"
+          },
+          "overridePacks": {
+            "type": "number"
+          },
+          "overrideDirectories": {
+            "type": "number"
+          },
+          "overrideErrorCount": {
+            "type": "number"
+          }
+        }
+      }
+    }
   },
   "usage": {
     "enabled": true,
@@ -19,7 +75,83 @@
       "news_command_opened",
       "settings_announcement_opened",
       "settings_announcement_reviewed"
-    ]
+    ],
+    "details": {
+      "config_editor_opened": {
+        "allowedFields": {
+          "source": {
+            "type": "enum",
+            "values": ["command"]
+          }
+        }
+      },
+      "config_editor_apply_requested": {
+        "allowedFields": {
+          "source": {
+            "type": "enum",
+            "values": ["settings_ui"]
+          },
+          "changedFileCount": {
+            "type": "number"
+          }
+        }
+      },
+      "config_editor_apply_succeeded": {
+        "allowedFields": {
+          "source": {
+            "type": "enum",
+            "values": ["settings_ui"]
+          },
+          "changedFileCount": {
+            "type": "number"
+          },
+          "result": {
+            "type": "enum",
+            "values": ["success"]
+          }
+        }
+      },
+      "reload_config_command_used": {
+        "allowedFields": {
+          "source": {
+            "type": "enum",
+            "values": ["command"]
+          }
+        }
+      },
+      "settings_page_opened": {
+        "allowedFields": {
+          "source": {
+            "type": "enum",
+            "values": ["command", "announcement", "api"]
+          }
+        }
+      },
+      "news_command_opened": {
+        "allowedFields": {
+          "source": {
+            "type": "enum",
+            "values": ["command"]
+          }
+        }
+      },
+      "settings_announcement_opened": {
+        "allowedFields": {
+          "source": {
+            "type": "enum",
+            "values": ["announcement"]
+          }
+        }
+      },
+      "settings_announcement_reviewed": {
+        "allowedFields": {
+          "source": {
+            "type": "enum",
+            "values": ["announcement"]
+          }
+        }
+      }
+    }
   },
   "ownerPluginIdentifiers": [
     "Alechilles:Alec's Tamework!"

--- a/src/test/java/com/alechilles/alecstamework/commands/TameworkReloadConfigCommandTest.java
+++ b/src/test/java/com/alechilles/alecstamework/commands/TameworkReloadConfigCommandTest.java
@@ -1,0 +1,20 @@
+package com.alechilles.alecstamework.commands;
+
+import com.alechilles.alecstamework.config.overrides.TwConfigOverrideManager;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TameworkReloadConfigCommandTest {
+
+    @Test
+    void reloadResultLabelDistinguishesPartialReloads() {
+        assertEquals("success", TameworkReloadConfigTelemetry.reloadResultLabel(TwConfigOverrideManager.ReloadResult.empty()));
+        assertEquals("partial", TameworkReloadConfigTelemetry.reloadResultLabel(new TwConfigOverrideManager.ReloadResult(
+                1,
+                1,
+                List.of("Bad override")
+        )));
+    }
+}

--- a/src/test/java/com/alechilles/alecstamework/metrics/CrashTelemetryServiceTest.java
+++ b/src/test/java/com/alechilles/alecstamework/metrics/CrashTelemetryServiceTest.java
@@ -1,5 +1,6 @@
 package com.alechilles.alecstamework.metrics;
 
+import com.alechilles.alecstelemetry.api.TelemetryEventContext;
 import com.alechilles.alecstelemetry.crash.CrashReportClient;
 import com.alechilles.alecstelemetry.crash.CrashReportEnvelope;
 import com.alechilles.alecstelemetry.project.TelemetryProjectDescriptor;
@@ -87,6 +88,33 @@ class CrashTelemetryServiceTest {
         assertEquals(0, payload.getAsJsonArray("breadcrumbs").size());
     }
 
+    @Test
+    void typedUsageContextPromotesFieldsAndValidatedDetails() {
+        SequencedClient client = new SequencedClient(CrashReportClient.UploadResult.success(204));
+        CrashTelemetryService service = createService(true, true, client);
+
+        service.recordUsage(
+                "debug_usage",
+                TelemetryEventContext.usage()
+                        .subsystem("settings")
+                        .featureKey("settings_page")
+                        .entryPoint("/tw settings")
+                        .runtimeSide("server")
+                        .detail("source", "settings_ui")
+                        .detail("ignored", "drop me")
+                        .build()
+        );
+        service.flushPendingReportsNow("typed-context");
+
+        JsonObject payload = JsonParser.parseString(client.payloads.getFirst()).getAsJsonObject();
+        assertEquals("settings", payload.get("subsystem").getAsString());
+        assertEquals("settings_page", payload.get("featureKey").getAsString());
+        assertEquals("/tw settings", payload.get("entryPoint").getAsString());
+        assertEquals("server", payload.get("runtimeSide").getAsString());
+        assertEquals("settings_ui", payload.getAsJsonObject("details").get("source").getAsString());
+        assertTrue(!payload.getAsJsonObject("details").has("ignored"));
+    }
+
     @Nonnull
     private CrashTelemetryService createService(boolean enabled,
                                                 boolean breadcrumbsEnabled,
@@ -127,7 +155,14 @@ class CrashTelemetryServiceTest {
                   },
                   "usage": {
                     "enabled": true,
-                    "allowedEvents": ["debug_usage"]
+                    "allowedEvents": ["debug_usage"],
+                    "details": {
+                      "debug_usage": {
+                        "allowedFields": {
+                          "source": { "type": "enum", "values": ["command", "settings_ui"] }
+                        }
+                      }
+                    }
                   },
                   "defaults": {
                     "enabled": true,

--- a/src/test/java/com/alechilles/alecstamework/metrics/CrashTelemetryServiceTest.java
+++ b/src/test/java/com/alechilles/alecstamework/metrics/CrashTelemetryServiceTest.java
@@ -115,10 +115,79 @@ class CrashTelemetryServiceTest {
         assertTrue(!payload.getAsJsonObject("details").has("ignored"));
     }
 
+    @Test
+    void disabledErrorAndLifecycleEventsReturnFalseWithoutQueueing() {
+        CrashTelemetryService service = createService(
+                true,
+                true,
+                new SequencedClient(),
+                """
+                  "events": {
+                    "errors": { "enabled": false },
+                    "lifecycle": { "enabled": false }
+                  },
+                """
+        );
+
+        assertFalse(service.recordError("disabled_error", testThrowable("disabled error"), "detail"));
+        assertFalse(service.recordLifecycle("disabled_lifecycle", 123, false, "detail"));
+        assertEquals(0, service.diagnostics().pendingReports());
+    }
+
+    @Test
+    void automaticBreadcrumbFlagControlsEventBreadcrumbDetails() {
+        SequencedClient client = new SequencedClient(CrashReportClient.UploadResult.success(204));
+        CrashTelemetryService service = createService(
+                true,
+                true,
+                client,
+                """
+                  "events": {
+                    "errors": { "enabled": true },
+                    "breadcrumbs": { "enabled": true, "automatic": false }
+                  },
+                """
+        );
+
+        service.recordBreadcrumb("settings", "Opened settings.");
+        assertTrue(service.recordError("debug_error", testThrowable("with breadcrumb"), "detail"));
+        service.flushPendingReportsNow("automatic-breadcrumbs-disabled");
+
+        JsonObject payload = JsonParser.parseString(client.payloads.getFirst()).getAsJsonObject();
+        assertFalse(payload.getAsJsonObject("details").has("breadcrumbs"));
+
+        service.captureSetupFailure(testThrowable("crash still gets breadcrumbs"));
+        service.flushPendingReportsNow("manual-breadcrumbs-still-enabled");
+
+        JsonObject crashPayload = JsonParser.parseString(client.payloads.getLast()).getAsJsonObject();
+        var crashBreadcrumbs = crashPayload.getAsJsonArray("breadcrumbs");
+        assertTrue(crashBreadcrumbs.size() >= 1);
+        assertEquals("settings", crashBreadcrumbs.get(0).getAsJsonObject().get("category").getAsString());
+    }
+
+    @Test
+    void typedContextDropsNullableDetailValuesBeforeCopying() {
+        TelemetryEventContext context = TelemetryEventContext.usage()
+                .detail("kept", 42)
+                .detail("missing", null)
+                .build();
+
+        assertEquals(42, context.details().get("kept"));
+        assertFalse(context.details().containsKey("missing"));
+    }
+
     @Nonnull
     private CrashTelemetryService createService(boolean enabled,
                                                 boolean breadcrumbsEnabled,
                                                 CrashReportClient client) {
+        return createService(enabled, breadcrumbsEnabled, client, "");
+    }
+
+    @Nonnull
+    private CrashTelemetryService createService(boolean enabled,
+                                                boolean breadcrumbsEnabled,
+                                                CrashReportClient client,
+                                                @Nonnull String extraDescriptorFields) {
         Path telemetryRoot = tempDir.resolve("Telemetry");
         Path settingsPath = tempDir.resolve("Settings").resolve(CrashTelemetrySettings.FILE_NAME);
         CrashTelemetrySettings compatibilitySettings = new CrashTelemetrySettings(
@@ -148,6 +217,7 @@ class CrashTelemetryServiceTest {
                   "runtimeMode": "embedded",
                   "ownerPluginIdentifiers": ["Alechilles:Alec's Tamework!"],
                   "packagePrefixes": ["com.alechilles.alecstamework"],
+                %s
                   "performance": {
                     "enabled": true,
                     "sampleRate": 1.0,
@@ -172,7 +242,7 @@ class CrashTelemetryServiceTest {
                     "url": "https://example.invalid/telemetry"
                   }
                 }
-                """,
+                """.formatted(extraDescriptorFields),
                 null
         );
         TelemetryProjectRegistration registration = new TelemetryProjectRegistration(

--- a/src/test/java/com/alechilles/alecstamework/metrics/CrashTelemetryServiceTest.java
+++ b/src/test/java/com/alechilles/alecstamework/metrics/CrashTelemetryServiceTest.java
@@ -116,6 +116,26 @@ class CrashTelemetryServiceTest {
     }
 
     @Test
+    void typedErrorContextIncludesStructuredDetails() {
+        SequencedClient client = new SequencedClient(CrashReportClient.UploadResult.success(204));
+        CrashTelemetryService service = createService(true, true, client);
+
+        assertTrue(service.recordError(
+                "debug_error",
+                testThrowable("context details"),
+                TelemetryEventContext.error()
+                        .detail("source", "settings_ui")
+                        .detail("overrideErrorCount", 2)
+                        .build()
+        ));
+        service.flushPendingReportsNow("typed-error-context");
+
+        JsonObject payload = JsonParser.parseString(client.payloads.getFirst()).getAsJsonObject();
+        assertEquals("settings_ui", payload.getAsJsonObject("details").get("source").getAsString());
+        assertEquals(2, payload.getAsJsonObject("details").get("overrideErrorCount").getAsInt());
+    }
+
+    @Test
     void disabledErrorAndLifecycleEventsReturnFalseWithoutQueueing() {
         CrashTelemetryService service = createService(
                 true,

--- a/src/test/java/com/alechilles/alecstamework/metrics/CrashTelemetryServiceTest.java
+++ b/src/test/java/com/alechilles/alecstamework/metrics/CrashTelemetryServiceTest.java
@@ -136,6 +136,29 @@ class CrashTelemetryServiceTest {
     }
 
     @Test
+    void typedLifecycleContextIncludesStructuredDetails() {
+        SequencedClient client = new SequencedClient(CrashReportClient.UploadResult.success(204));
+        CrashTelemetryService service = createService(true, true, client);
+
+        assertTrue(service.recordLifecycle(
+                "debug_lifecycle",
+                123,
+                true,
+                TelemetryEventContext.lifecycle()
+                        .detail("source", "command")
+                        .detail("result", "partial")
+                        .detail("overrideErrorCount", 2)
+                        .build()
+        ));
+        service.flushPendingReportsNow("typed-lifecycle-context");
+
+        JsonObject payload = JsonParser.parseString(client.payloads.getFirst()).getAsJsonObject();
+        assertEquals("command", payload.getAsJsonObject("details").get("source").getAsString());
+        assertEquals("partial", payload.getAsJsonObject("details").get("result").getAsString());
+        assertEquals(2, payload.getAsJsonObject("details").get("overrideErrorCount").getAsInt());
+    }
+
+    @Test
     void disabledErrorAndLifecycleEventsReturnFalseWithoutQueueing() {
         CrashTelemetryService service = createService(
                 true,


### PR DESCRIPTION
## Summary
- Syncs the embedded telemetry runtime with typed event context support and descriptor-based event/detail controls.
- Adds Tamework usage/performance context for plugin lifecycle, config reload/editor, settings/news, announcements, and telemetry debug commands.
- Keeps event names stable while adding sanitized mod-specific details such as source, changed file count, reload counts, and override error counts.

## Verification
- `./mvnw.cmd test` (443 tests)
- Thread-safety grep for player access patterns only returned the existing `CommandItemFeatureHandler` hit.
