### PR TITLE
[codex] Add spawn marker debug commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+- Added `/tw showspawnmarkers [radius|off]` to render nearby loaded Hytale spawn markers with bright-pink player-local debug shapes and print marker IDs, NPC options, positions, spawn counts, manual-trigger status, and suppression state.
+- Added `/tw deletespawnmarker [range]` to delete the closest loaded spawn marker in the player's view path, clear the source block marker component when available, and report the marker ID, NPC options, and position.
+
+### Fixed
+- Fixed `/tw npcspawntamed` attachment overrides being replaced by the NPC's initial random attachment choice after the sync system ran.
+
 ## 2.8.6 - Breeding Families + Runtime Compatibility - 2026-04-26
 
 ### Added

--- a/docs/Actions-Sensors-Components.md
+++ b/docs/Actions-Sensors-Components.md
@@ -86,6 +86,8 @@ This file maps Tamework's currently registered NPC builders, item interactions, 
 - `/tw debugspawnerlocation [on|off]`
 - `/tw debugdespawn [on|off] [RoleName|all|clear]`
 - `/tw debuglag [on|off]`
+- `/tw showspawnmarkers [radius|off]`
+- `/tw deletespawnmarker [range]`
 
 ## Notes
 - Components persist across reloads.

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkCommandRoot.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkCommandRoot.java
@@ -45,6 +45,8 @@ public final class TameworkCommandRoot extends AbstractCommandCollection {
         addSubCommand(new TameworkDebugNeedsSeekCommand());
         addSubCommand(new TameworkDebugFlyingCompanionCommand());
         addSubCommand(new TameworkShowHitboxesCommand());
+        addSubCommand(new TameworkShowSpawnMarkersCommand());
+        addSubCommand(new TameworkDeleteSpawnMarkerCommand());
         addSubCommand(new TameworkDebugDbCommand());
         addSubCommand(new TameworkDebugCrashTelemetryCommand());
         addSubCommand(new TameworkDebugReviveReadyCommand());

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkDeleteSpawnMarkerCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkDeleteSpawnMarkerCommand.java
@@ -1,0 +1,247 @@
+package com.alechilles.alecstamework.commands;
+
+import com.hypixel.hytale.component.ArchetypeChunk;
+import com.hypixel.hytale.component.CommandBuffer;
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.RemoveReason;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.component.query.Query;
+import com.hypixel.hytale.math.util.ChunkUtil;
+import com.hypixel.hytale.math.vector.Vector3d;
+import com.hypixel.hytale.math.vector.Vector3f;
+import com.hypixel.hytale.math.vector.Vector3i;
+import com.hypixel.hytale.server.core.Message;
+import com.hypixel.hytale.server.core.command.system.CommandContext;
+import com.hypixel.hytale.server.core.command.system.basecommands.AbstractPlayerCommand;
+import com.hypixel.hytale.server.core.modules.block.BlockModule;
+import com.hypixel.hytale.server.core.modules.entity.component.HeadRotation;
+import com.hypixel.hytale.server.core.modules.entity.component.TransformComponent;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.chunk.WorldChunk;
+import com.hypixel.hytale.server.core.universe.world.World;
+import com.hypixel.hytale.server.core.universe.world.storage.ChunkStore;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import com.hypixel.hytale.server.spawning.assets.spawnmarker.config.SpawnMarker;
+import com.hypixel.hytale.server.spawning.blockstates.SpawnMarkerBlock;
+import com.hypixel.hytale.server.spawning.blockstates.SpawnMarkerBlockReference;
+import com.hypixel.hytale.server.spawning.spawnmarkers.SpawnMarkerEntity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Deletes the closest loaded spawn marker entity in the player's view ray.
+ */
+public final class TameworkDeleteSpawnMarkerCommand extends AbstractPlayerCommand {
+    private static final int MAX_NPC_SUMMARY_ROWS = 4;
+
+    public TameworkDeleteSpawnMarkerCommand() {
+        super("deletespawnmarker", "Delete the loaded spawn marker you are looking at.");
+        setAllowsExtraArguments(true);
+    }
+
+    @Override
+    protected void execute(@Nonnull CommandContext commandContext,
+                           @Nonnull Store<EntityStore> store,
+                           @Nonnull Ref<EntityStore> ref,
+                           @Nonnull PlayerRef playerRef,
+                           @Nonnull World world) {
+        TameworkDeleteSpawnMarkerCommandSupport.ParseResult parse =
+                TameworkDeleteSpawnMarkerCommandSupport.parse(commandContext.getInputString());
+        if (parse.mode() == TameworkDeleteSpawnMarkerCommandSupport.Mode.INVALID) {
+            commandContext.sender().sendMessage(Message.raw("Usage: /tw deletespawnmarker [range]"));
+            return;
+        }
+
+        TransformComponent playerTransform = store.getComponent(ref, TransformComponent.getComponentType());
+        if (playerTransform == null) {
+            commandContext.sender().sendMessage(Message.raw("Unable to resolve your position."));
+            return;
+        }
+
+        Vector3d playerPosition = new Vector3d(playerTransform.getPosition());
+        Vector3d forward = resolveForward(store, ref, playerTransform);
+        TargetMarker target = findTargetMarker(store, playerPosition, forward, parse.range());
+        if (target == null) {
+            commandContext.sender().sendMessage(Message.raw(
+                    "No loaded spawn marker found in front of you within "
+                            + formatNumber(parse.range())
+                            + " blocks."
+            ));
+            return;
+        }
+
+        if (target.ref == null || !target.ref.isValid()) {
+            commandContext.sender().sendMessage(Message.raw("Target spawn marker is no longer valid."));
+            return;
+        }
+
+        store.removeEntity(target.ref, RemoveReason.REMOVE);
+        boolean removedSourceBlockComponent = removeSourceBlockMarkerComponent(world, target.blockPosition);
+        commandContext.sender().sendMessage(Message.raw(
+                "Deleted loaded spawn marker "
+                        + target.markerId
+                        + " at "
+                        + formatPosition(target.position)
+                        + ", npc="
+                        + target.npcSummary
+                        + ", distance="
+                        + formatNumber(target.score.forwardDistance())
+                        + target.blockBackedSuffix(removedSourceBlockComponent)
+                        + "."
+        ));
+    }
+
+    @Nullable
+    private static TargetMarker findTargetMarker(@Nonnull Store<EntityStore> store,
+                                                 @Nonnull Vector3d playerPosition,
+                                                 @Nonnull Vector3d forward,
+                                                 double range) {
+        List<TargetMarker> candidates = new ArrayList<>();
+        store.forEachChunk(Query.any(), (ArchetypeChunk<EntityStore> chunk, CommandBuffer<EntityStore> commandBuffer) -> {
+            int size = chunk.size();
+            for (int i = 0; i < size; i++) {
+                SpawnMarkerEntity marker = chunk.getComponent(i, SpawnMarkerEntity.getComponentType());
+                if (marker == null) {
+                    continue;
+                }
+                TransformComponent transform = chunk.getComponent(i, TransformComponent.getComponentType());
+                if (transform == null) {
+                    continue;
+                }
+
+                Vector3d markerPosition = new Vector3d(transform.getPosition());
+                TameworkDeleteSpawnMarkerCommandSupport.TargetScore score =
+                        TameworkDeleteSpawnMarkerCommandSupport.scoreCandidate(
+                                playerPosition,
+                                forward,
+                                markerPosition,
+                                range
+                        );
+                if (score == null || !score.matches()) {
+                    continue;
+                }
+
+                SpawnMarker spawnMarker = marker.getCachedMarker();
+                if (spawnMarker == null) {
+                    spawnMarker = resolveSpawnMarker(marker.getSpawnMarkerId());
+                }
+                SpawnMarkerBlockReference blockReference =
+                        chunk.getComponent(i, SpawnMarkerBlockReference.getComponentType());
+                candidates.add(new TargetMarker(
+                        chunk.getReferenceTo(i),
+                        marker.getSpawnMarkerId(),
+                        describeNpcOptions(spawnMarker),
+                        markerPosition,
+                        score,
+                        blockReference != null ? blockReference.getBlockPosition() : null
+                ));
+            }
+        });
+
+        TargetMarker best = null;
+        for (TargetMarker candidate : candidates) {
+            if (best == null || candidate.score.isBetterThan(best.score)) {
+                best = candidate;
+            }
+        }
+        return best;
+    }
+
+    @Nonnull
+    private static Vector3d resolveForward(@Nonnull Store<EntityStore> store,
+                                           @Nonnull Ref<EntityStore> playerRef,
+                                           @Nonnull TransformComponent playerTransform) {
+        Vector3f rotation = new Vector3f(playerTransform.getRotation());
+        HeadRotation headRotation = store.getComponent(playerRef, HeadRotation.getComponentType());
+        Vector3f headRot = headRotation != null ? headRotation.getRotation() : rotation;
+
+        Vector3f forward = new Vector3f(Vector3f.FORWARD);
+        forward.rotateY(headRot.getYaw());
+        forward.rotateX(headRot.getPitch());
+        forward.normalize();
+        return new Vector3d(forward.x, forward.y, forward.z);
+    }
+
+    private static String describeNpcOptions(SpawnMarker spawnMarker) {
+        if (spawnMarker == null || spawnMarker.getWeightedConfigurations() == null) {
+            return "unknown";
+        }
+
+        List<String> npcIds = new ArrayList<>();
+        spawnMarker.getWeightedConfigurations().forEach(configuration -> {
+            if (configuration != null && configuration.getNpc() != null && !configuration.getNpc().isBlank()) {
+                npcIds.add(configuration.getNpc());
+            }
+        });
+        return TameworkShowSpawnMarkersCommandSupport.formatNpcSummary(npcIds, MAX_NPC_SUMMARY_ROWS);
+    }
+
+    private static SpawnMarker resolveSpawnMarker(String markerId) {
+        if (markerId == null || markerId.isBlank()) {
+            return null;
+        }
+        try {
+            return SpawnMarker.getAssetMap().getAsset(markerId);
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    private static boolean removeSourceBlockMarkerComponent(@Nonnull World world, @Nullable Vector3i blockPosition) {
+        if (blockPosition == null || world.getChunkStore() == null) {
+            return false;
+        }
+
+        WorldChunk chunk = world.getChunkIfInMemory(ChunkUtil.indexChunkFromBlock(blockPosition.x, blockPosition.z));
+        if (chunk == null) {
+            return false;
+        }
+        Ref<ChunkStore> blockRef = chunk.getBlockComponentEntity(blockPosition.x, blockPosition.y, blockPosition.z);
+        if (blockRef == null || !blockRef.isValid()) {
+            return false;
+        }
+
+        Store<ChunkStore> chunkStore = world.getChunkStore().getStore();
+        boolean removed = chunkStore.removeComponentIfExists(blockRef, SpawnMarkerBlock.getComponentType());
+        if (removed) {
+            BlockModule.BlockStateInfo blockStateInfo =
+                    chunkStore.getComponent(blockRef, BlockModule.BlockStateInfo.getComponentType());
+            if (blockStateInfo != null) {
+                blockStateInfo.markNeedsSaving(chunkStore);
+            }
+        }
+        return removed;
+    }
+
+    private static String formatPosition(@Nonnull Vector3d position) {
+        return String.format(Locale.ROOT, "(%.2f, %.2f, %.2f)", position.x, position.y, position.z);
+    }
+
+    private static String formatNumber(double value) {
+        return String.format(Locale.ROOT, "%.1f", value);
+    }
+
+    private record TargetMarker(Ref<EntityStore> ref,
+                                String markerId,
+                                String npcSummary,
+                                Vector3d position,
+                                TameworkDeleteSpawnMarkerCommandSupport.TargetScore score,
+                                Vector3i blockPosition) {
+        String blockBackedSuffix(boolean removedSourceBlockComponent) {
+            if (blockPosition == null) {
+                return "";
+            }
+            return ", sourceBlock=("
+                    + blockPosition.x
+                    + ", "
+                    + blockPosition.y
+                    + ", "
+                    + blockPosition.z
+                    + "), sourceBlockMarkerRemoved="
+                    + removedSourceBlockComponent;
+        }
+    }
+}

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkDeleteSpawnMarkerCommandSupport.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkDeleteSpawnMarkerCommandSupport.java
@@ -1,0 +1,114 @@
+package com.alechilles.alecstamework.commands;
+
+import com.hypixel.hytale.math.vector.Vector3d;
+import java.util.Locale;
+
+final class TameworkDeleteSpawnMarkerCommandSupport {
+    static final double DEFAULT_RANGE = 10.0;
+    static final double MIN_RANGE = 1.0;
+    static final double MAX_RANGE = 64.0;
+    private static final double MIN_FORWARD_DISTANCE = 0.25;
+    private static final double MIN_RAY_RADIUS = 0.75;
+    private static final double MAX_RAY_RADIUS = 2.0;
+
+    private TameworkDeleteSpawnMarkerCommandSupport() {
+    }
+
+    static ParseResult parse(String input) {
+        String arg = getArg(input, 2);
+        if (arg == null || arg.isBlank()) {
+            return new ParseResult(Mode.DELETE, DEFAULT_RANGE);
+        }
+        String normalized = arg.trim().toLowerCase(Locale.ROOT);
+        try {
+            double parsed = Double.parseDouble(normalized);
+            if (!Double.isFinite(parsed) || parsed <= 0.0) {
+                return new ParseResult(Mode.INVALID, DEFAULT_RANGE);
+            }
+            return new ParseResult(Mode.DELETE, clamp(parsed, MIN_RANGE, MAX_RANGE));
+        } catch (NumberFormatException ignored) {
+            return new ParseResult(Mode.INVALID, DEFAULT_RANGE);
+        }
+    }
+
+    static TargetScore scoreCandidate(Vector3d origin, Vector3d forward, Vector3d markerPosition, double range) {
+        if (origin == null || forward == null || markerPosition == null || !Double.isFinite(range) || range <= 0.0) {
+            return null;
+        }
+
+        double forwardLength = length(forward.x, forward.y, forward.z);
+        if (!(forwardLength > 0.0001)) {
+            return null;
+        }
+
+        double fx = forward.x / forwardLength;
+        double fy = forward.y / forwardLength;
+        double fz = forward.z / forwardLength;
+        double tx = markerPosition.x - origin.x;
+        double ty = markerPosition.y - origin.y;
+        double tz = markerPosition.z - origin.z;
+        double forwardDistance = (tx * fx) + (ty * fy) + (tz * fz);
+        if (forwardDistance < MIN_FORWARD_DISTANCE || forwardDistance > range) {
+            return TargetScore.noMatch(forwardDistance, Double.NaN);
+        }
+
+        double distanceSq = (tx * tx) + (ty * ty) + (tz * tz);
+        double perpendicularSq = Math.max(0.0, distanceSq - (forwardDistance * forwardDistance));
+        double perpendicularDistance = Math.sqrt(perpendicularSq);
+        double allowedRadius = clamp(0.6 + (forwardDistance * 0.2), MIN_RAY_RADIUS, MAX_RAY_RADIUS);
+        if (perpendicularDistance > allowedRadius) {
+            return TargetScore.noMatch(forwardDistance, perpendicularDistance);
+        }
+
+        double normalizedOffset = perpendicularDistance / allowedRadius;
+        double normalizedDistance = forwardDistance / Math.max(range, 0.0001);
+        double ranking = normalizedOffset + (normalizedDistance * 0.25);
+        return new TargetScore(true, ranking, forwardDistance, perpendicularDistance);
+    }
+
+    private static double clamp(double value, double min, double max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private static double length(double x, double y, double z) {
+        return Math.sqrt((x * x) + (y * y) + (z * z));
+    }
+
+    private static String getArg(String input, int index) {
+        if (input == null) {
+            return null;
+        }
+        String[] tokens = input.trim().split("\\s+");
+        if (tokens.length <= index) {
+            return null;
+        }
+        return tokens[index];
+    }
+
+    enum Mode {
+        DELETE,
+        INVALID
+    }
+
+    record ParseResult(Mode mode, double range) {
+    }
+
+    record TargetScore(boolean matches,
+                       double ranking,
+                       double forwardDistance,
+                       double perpendicularDistance) {
+        static TargetScore noMatch(double forwardDistance, double perpendicularDistance) {
+            return new TargetScore(false, Double.POSITIVE_INFINITY, forwardDistance, perpendicularDistance);
+        }
+
+        boolean isBetterThan(TargetScore other) {
+            if (!matches) {
+                return false;
+            }
+            if (other == null || !other.matches) {
+                return true;
+            }
+            return ranking < other.ranking;
+        }
+    }
+}

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkShowSpawnMarkersCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkShowSpawnMarkersCommand.java
@@ -1,0 +1,343 @@
+package com.alechilles.alecstamework.commands;
+
+import com.hypixel.hytale.component.ArchetypeChunk;
+import com.hypixel.hytale.component.CommandBuffer;
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.component.query.Query;
+import com.hypixel.hytale.math.matrix.Matrix4d;
+import com.hypixel.hytale.math.vector.Vector3d;
+import com.hypixel.hytale.math.vector.Vector3f;
+import com.hypixel.hytale.protocol.DebugShape;
+import com.hypixel.hytale.protocol.ToClientPacket;
+import com.hypixel.hytale.protocol.packets.player.ClearDebugShapes;
+import com.hypixel.hytale.protocol.packets.player.DisplayDebug;
+import com.hypixel.hytale.server.core.Message;
+import com.hypixel.hytale.server.core.command.system.CommandContext;
+import com.hypixel.hytale.server.core.command.system.basecommands.AbstractPlayerCommand;
+import com.hypixel.hytale.server.core.modules.debug.DebugUtils;
+import com.hypixel.hytale.server.core.modules.entity.component.TransformComponent;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.World;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import com.hypixel.hytale.server.spawning.assets.spawnmarker.config.SpawnMarker;
+import com.hypixel.hytale.server.spawning.spawnmarkers.SpawnMarkerEntity;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nonnull;
+
+/**
+ * Toggles player-local debug rendering for loaded Hytale spawn marker entities.
+ */
+public final class TameworkShowSpawnMarkersCommand extends AbstractPlayerCommand {
+    private static final long TRACK_INTERVAL_MS = 1000L;
+    private static final float TRACK_RENDER_SECONDS = 1.25f;
+    private static final TameworkShowSpawnMarkersCommandSupport.DebugStyle DEBUG_STYLE =
+            TameworkShowSpawnMarkersCommandSupport.debugStyle();
+    private static final Vector3f MARKER_COLOR =
+            new Vector3f(DEBUG_STYLE.red(), DEBUG_STYLE.green(), DEBUG_STYLE.blue());
+    private static final int SHAPE_FLAGS = resolveShapeFlags();
+    private static final int MAX_SUMMARY_ROWS = 8;
+    private static final int MAX_NPC_SUMMARY_ROWS = 4;
+    private static final AtomicLong TRACKING_SEQUENCE = new AtomicLong();
+    private static final ConcurrentHashMap<UUID, TrackingSession> ACTIVE_TRACKING = new ConcurrentHashMap<>();
+
+    public TameworkShowSpawnMarkersCommand() {
+        super("showspawnmarkers", "Toggle player-local spawn marker debug rendering.");
+        setAllowsExtraArguments(true);
+    }
+
+    @Override
+    protected void execute(@Nonnull CommandContext commandContext,
+                           @Nonnull Store<EntityStore> store,
+                           @Nonnull Ref<EntityStore> ref,
+                           @Nonnull PlayerRef playerRef,
+                           @Nonnull World world) {
+        UUID playerUuid = playerRef.getUuid();
+        if (playerUuid == null) {
+            commandContext.sender().sendMessage(Message.raw("Unable to resolve your player UUID."));
+            return;
+        }
+
+        TameworkShowSpawnMarkersCommandSupport.ParseResult parse =
+                TameworkShowSpawnMarkersCommandSupport.parse(commandContext.getInputString());
+        if (parse.mode() == TameworkShowSpawnMarkersCommandSupport.Mode.INVALID) {
+            commandContext.sender().sendMessage(Message.raw(
+                    "Usage: /tw showspawnmarkers [radius|off]"
+            ));
+            return;
+        }
+        if (parse.mode() == TameworkShowSpawnMarkersCommandSupport.Mode.OFF) {
+            TrackingSession removed = ACTIVE_TRACKING.remove(playerUuid);
+            clearDebugForPlayer(playerRef);
+            commandContext.sender().sendMessage(Message.raw(
+                    removed != null ? "Spawn marker debug rendering disabled." : "Spawn marker debug rendering was not active."
+            ));
+            return;
+        }
+
+        TransformComponent playerTransform = store.getComponent(ref, TransformComponent.getComponentType());
+        if (playerTransform == null) {
+            commandContext.sender().sendMessage(Message.raw("Unable to resolve your position."));
+            return;
+        }
+
+        List<MarkerSnapshot> markers = collectMarkers(store, playerTransform.getPosition(), parse.radius());
+        renderMarkers(playerRef, markers);
+
+        long sessionId = TRACKING_SEQUENCE.incrementAndGet();
+        ACTIVE_TRACKING.put(playerUuid, new TrackingSession(sessionId, world, parse.radius()));
+        scheduleTrackingTick(world, playerRef, playerUuid, sessionId);
+
+        commandContext.sender().sendMessage(Message.raw(
+                "Spawn marker debug rendering enabled within "
+                        + formatNumber(parse.radius())
+                        + " blocks. Found "
+                        + markers.size()
+                        + " loaded marker"
+                        + (markers.size() == 1 ? "" : "s")
+                        + ". Run /tw showspawnmarkers off to disable."
+        ));
+        sendMarkerSummary(commandContext, markers);
+    }
+
+    private static void sendMarkerSummary(@Nonnull CommandContext commandContext, @Nonnull List<MarkerSnapshot> markers) {
+        int rows = Math.min(MAX_SUMMARY_ROWS, markers.size());
+        for (int i = 0; i < rows; i++) {
+            MarkerSnapshot marker = markers.get(i);
+            commandContext.sender().sendMessage(Message.raw(
+                    "  "
+                            + marker.markerId
+                            + " at "
+                            + formatPosition(marker.position)
+                            + ", distance="
+                            + formatNumber(marker.distance)
+                            + ", npc="
+                            + marker.npcSummary
+                            + ", spawnCount="
+                            + marker.spawnCount
+                            + ", manual="
+                            + marker.manualTrigger
+                            + ", suppressed="
+                            + marker.suppressed
+            ));
+        }
+        if (markers.size() > rows) {
+            commandContext.sender().sendMessage(Message.raw(
+                    "  ...and " + (markers.size() - rows) + " more loaded marker(s)."
+            ));
+        }
+    }
+
+    private static List<MarkerSnapshot> collectMarkers(@Nonnull Store<EntityStore> store,
+                                                       @Nonnull Vector3d playerPosition,
+                                                       double radius) {
+        List<MarkerSnapshot> markers = new ArrayList<>();
+        double radiusSq = radius * radius;
+        store.forEachChunk(Query.any(), (ArchetypeChunk<EntityStore> chunk, CommandBuffer<EntityStore> commandBuffer) -> {
+            int size = chunk.size();
+            for (int i = 0; i < size; i++) {
+                SpawnMarkerEntity marker = chunk.getComponent(i, SpawnMarkerEntity.getComponentType());
+                if (marker == null) {
+                    continue;
+                }
+                TransformComponent transform = chunk.getComponent(i, TransformComponent.getComponentType());
+                if (transform == null) {
+                    continue;
+                }
+                Vector3d position = transform.getPosition();
+                double dx = position.x - playerPosition.x;
+                double dy = position.y - playerPosition.y;
+                double dz = position.z - playerPosition.z;
+                double distanceSq = (dx * dx) + (dy * dy) + (dz * dz);
+                if (distanceSq > radiusSq) {
+                    continue;
+                }
+                SpawnMarker spawnMarker = marker.getCachedMarker();
+                if (spawnMarker == null) {
+                    spawnMarker = resolveSpawnMarker(marker.getSpawnMarkerId());
+                }
+                markers.add(new MarkerSnapshot(
+                        marker.getSpawnMarkerId(),
+                        describeNpcOptions(spawnMarker),
+                        new Vector3d(position),
+                        Math.sqrt(distanceSq),
+                        marker.getSpawnCount(),
+                        marker.isManualTrigger(),
+                        marker.getSuppressedBy() != null && !marker.getSuppressedBy().isEmpty()
+                ));
+            }
+        });
+        markers.sort(Comparator.comparingDouble(marker -> marker.distance));
+        return markers;
+    }
+
+    private static void renderMarkers(@Nonnull PlayerRef playerRef, @Nonnull List<MarkerSnapshot> markers) {
+        for (MarkerSnapshot marker : markers) {
+            drawMarker(playerRef, marker);
+        }
+    }
+
+    private static void drawMarker(@Nonnull PlayerRef playerRef, @Nonnull MarkerSnapshot marker) {
+        drawBox(
+                playerRef,
+                marker.position,
+                DEBUG_STYLE.markerWidth(),
+                DEBUG_STYLE.markerHeight(),
+                DEBUG_STYLE.markerDepth(),
+                MARKER_COLOR,
+                TRACK_RENDER_SECONDS,
+                DEBUG_STYLE.markerAlpha()
+        );
+
+        Vector3d capPosition = new Vector3d(marker.position);
+        capPosition.y += DEBUG_STYLE.markerHeight() + 0.25;
+        drawBox(
+                playerRef,
+                capPosition,
+                DEBUG_STYLE.capWidth(),
+                DEBUG_STYLE.capHeight(),
+                DEBUG_STYLE.capDepth(),
+                marker.suppressed ? DebugUtils.COLOR_RED : DebugUtils.COLOR_YELLOW,
+                TRACK_RENDER_SECONDS,
+                DEBUG_STYLE.capAlpha()
+        );
+    }
+
+    private static String describeNpcOptions(SpawnMarker spawnMarker) {
+        if (spawnMarker == null || spawnMarker.getWeightedConfigurations() == null) {
+            return "unknown";
+        }
+
+        List<String> npcIds = new ArrayList<>();
+        spawnMarker.getWeightedConfigurations().forEach(configuration -> {
+            if (configuration != null && configuration.getNpc() != null && !configuration.getNpc().isBlank()) {
+                npcIds.add(configuration.getNpc());
+            }
+        });
+        return TameworkShowSpawnMarkersCommandSupport.formatNpcSummary(npcIds, MAX_NPC_SUMMARY_ROWS);
+    }
+
+    private static SpawnMarker resolveSpawnMarker(String markerId) {
+        if (markerId == null || markerId.isBlank()) {
+            return null;
+        }
+        try {
+            return SpawnMarker.getAssetMap().getAsset(markerId);
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    private static void drawBox(@Nonnull PlayerRef playerRef,
+                                @Nonnull Vector3d center,
+                                double width,
+                                double height,
+                                double depth,
+                                @Nonnull Vector3f color,
+                                float durationSeconds,
+                                float alpha) {
+        Matrix4d matrix = new Matrix4d();
+        matrix.identity();
+        matrix.translate(center.x, center.y + (height / 2.0), center.z);
+        matrix.scale(width, height, depth);
+        DisplayDebug packet = new DisplayDebug(
+                DebugShape.Cube,
+                matrix.asFloatData(),
+                new com.hypixel.hytale.protocol.Vector3f(color.x, color.y, color.z),
+                durationSeconds,
+                (byte) SHAPE_FLAGS,
+                null,
+                alpha
+        );
+        playerRef.getPacketHandler().write((ToClientPacket) packet);
+    }
+
+    private static void clearDebugForPlayer(@Nonnull PlayerRef playerRef) {
+        playerRef.getPacketHandler().write((ToClientPacket) new ClearDebugShapes());
+    }
+
+    private static void scheduleTrackingTick(@Nonnull World world,
+                                             @Nonnull PlayerRef playerRef,
+                                             @Nonnull UUID playerUuid,
+                                             long sessionId) {
+        CompletableFuture.runAsync(
+                () -> world.execute(() -> runTrackingTickOnWorldThread(world, playerRef, playerUuid, sessionId)),
+                CompletableFuture.delayedExecutor(TRACK_INTERVAL_MS, TimeUnit.MILLISECONDS)
+        );
+    }
+
+    private static void runTrackingTickOnWorldThread(@Nonnull World world,
+                                                     @Nonnull PlayerRef playerRef,
+                                                     @Nonnull UUID playerUuid,
+                                                     long sessionId) {
+        TrackingSession session = ACTIVE_TRACKING.get(playerUuid);
+        if (session == null || session.sessionId != sessionId) {
+            return;
+        }
+        if (session.world != world) {
+            ACTIVE_TRACKING.remove(playerUuid, session);
+            return;
+        }
+
+        Ref<EntityStore> playerEntityRef = playerRef.getReference();
+        if (playerEntityRef == null || !playerEntityRef.isValid()) {
+            ACTIVE_TRACKING.remove(playerUuid, session);
+            return;
+        }
+        Store<EntityStore> store = playerEntityRef.getStore();
+        if (store == null || store.getExternalData() == null || store.getExternalData().getWorld() != world) {
+            ACTIVE_TRACKING.remove(playerUuid, session);
+            return;
+        }
+        TransformComponent playerTransform = store.getComponent(playerEntityRef, TransformComponent.getComponentType());
+        if (playerTransform == null) {
+            ACTIVE_TRACKING.remove(playerUuid, session);
+            return;
+        }
+
+        renderMarkers(playerRef, collectMarkers(store, playerTransform.getPosition(), session.radius));
+        scheduleTrackingTick(world, playerRef, playerUuid, sessionId);
+    }
+
+    private static int resolveShapeFlags() {
+        return resolveOptionalDebugFlag("FLAG_FADE") | resolveOptionalDebugFlag("FLAG_NO_SOLID");
+    }
+
+    private static int resolveOptionalDebugFlag(@Nonnull String fieldName) {
+        try {
+            Field field = DebugUtils.class.getField(fieldName);
+            return field.getInt(null);
+        } catch (ReflectiveOperationException | SecurityException ignored) {
+            return 0;
+        }
+    }
+
+    private static String formatPosition(@Nonnull Vector3d position) {
+        return String.format(Locale.ROOT, "(%.2f, %.2f, %.2f)", position.x, position.y, position.z);
+    }
+
+    private static String formatNumber(double value) {
+        return String.format(Locale.ROOT, "%.1f", value);
+    }
+
+    private record TrackingSession(long sessionId, World world, double radius) {
+    }
+
+    private record MarkerSnapshot(String markerId,
+                                  String npcSummary,
+                                  Vector3d position,
+                                  double distance,
+                                  int spawnCount,
+                                  boolean manualTrigger,
+                                  boolean suppressed) {
+    }
+}

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkShowSpawnMarkersCommand.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkShowSpawnMarkersCommand.java
@@ -77,7 +77,9 @@ public final class TameworkShowSpawnMarkersCommand extends AbstractPlayerCommand
         }
         if (parse.mode() == TameworkShowSpawnMarkersCommandSupport.Mode.OFF) {
             TrackingSession removed = ACTIVE_TRACKING.remove(playerUuid);
-            clearDebugForPlayer(playerRef);
+            if (removed != null) {
+                clearDebugForPlayer(playerRef);
+            }
             commandContext.sender().sendMessage(Message.raw(
                     removed != null ? "Spawn marker debug rendering disabled." : "Spawn marker debug rendering was not active."
             ));

--- a/src/main/java/com/alechilles/alecstamework/commands/TameworkShowSpawnMarkersCommandSupport.java
+++ b/src/main/java/com/alechilles/alecstamework/commands/TameworkShowSpawnMarkersCommandSupport.java
@@ -1,0 +1,117 @@
+package com.alechilles.alecstamework.commands;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.StringJoiner;
+
+final class TameworkShowSpawnMarkersCommandSupport {
+    static final double DEFAULT_RADIUS = 64.0;
+    static final double MIN_RADIUS = 1.0;
+    static final double MAX_RADIUS = 256.0;
+    private static final DebugStyle DEBUG_STYLE = new DebugStyle(
+            1.0F,
+            0.05F,
+            0.85F,
+            0.75,
+            2.5,
+            0.75,
+            0.95F,
+            1.2,
+            0.35,
+            1.2,
+            0.95F
+    );
+
+    private TameworkShowSpawnMarkersCommandSupport() {
+    }
+
+    static ParseResult parse(String input) {
+        String arg = getArg(input, 2);
+        if (arg == null || arg.isBlank()) {
+            return new ParseResult(Mode.SHOW, DEFAULT_RADIUS);
+        }
+        String normalized = arg.trim().toLowerCase(Locale.ROOT);
+        if ("off".equals(normalized) || "false".equals(normalized) || "0".equals(normalized)) {
+            return new ParseResult(Mode.OFF, DEFAULT_RADIUS);
+        }
+        if ("on".equals(normalized) || "true".equals(normalized)) {
+            return new ParseResult(Mode.SHOW, DEFAULT_RADIUS);
+        }
+        try {
+            double parsed = Double.parseDouble(normalized);
+            if (!Double.isFinite(parsed) || parsed <= 0.0) {
+                return new ParseResult(Mode.INVALID, DEFAULT_RADIUS);
+            }
+            return new ParseResult(Mode.SHOW, clamp(parsed, MIN_RADIUS, MAX_RADIUS));
+        } catch (NumberFormatException ignored) {
+            return new ParseResult(Mode.INVALID, DEFAULT_RADIUS);
+        }
+    }
+
+    static DebugStyle debugStyle() {
+        return DEBUG_STYLE;
+    }
+
+    static String formatNpcSummary(List<String> npcIds, int maxEntries) {
+        if (npcIds == null || npcIds.isEmpty() || maxEntries <= 0) {
+            return "unknown";
+        }
+
+        int count = Math.min(maxEntries, npcIds.size());
+        StringJoiner joiner = new StringJoiner(", ");
+        for (int i = 0; i < count; i++) {
+            String npcId = npcIds.get(i);
+            if (npcId == null || npcId.isBlank()) {
+                continue;
+            }
+            joiner.add(npcId);
+        }
+
+        String summary = joiner.toString();
+        if (summary.isBlank()) {
+            return "unknown";
+        }
+        int remaining = npcIds.size() - count;
+        if (remaining > 0) {
+            return summary + ", +" + remaining + " more";
+        }
+        return summary;
+    }
+
+    private static double clamp(double value, double min, double max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private static String getArg(String input, int index) {
+        if (input == null) {
+            return null;
+        }
+        String[] tokens = input.trim().split("\\s+");
+        if (tokens.length <= index) {
+            return null;
+        }
+        return tokens[index];
+    }
+
+    enum Mode {
+        SHOW,
+        OFF,
+        INVALID
+    }
+
+    record ParseResult(Mode mode, double radius) {
+    }
+
+    record DebugStyle(float red,
+                      float green,
+                      float blue,
+                      double markerWidth,
+                      double markerHeight,
+                      double markerDepth,
+                      float markerAlpha,
+                      double capWidth,
+                      double capHeight,
+                      double capDepth,
+                      float capAlpha) {
+    }
+}

--- a/src/main/java/com/alechilles/alecstamework/items/SpawnerAttachmentService.java
+++ b/src/main/java/com/alechilles/alecstamework/items/SpawnerAttachmentService.java
@@ -71,6 +71,6 @@ final class SpawnerAttachmentService {
             logger.at(Level.WARNING).log("Spawner stub: failed to apply attachment selections to spawned NPC.");
             return;
         }
-        CompanionAttachmentStateService.seedStoredAttachments(npcRef, store);
+        CompanionAttachmentStateService.replaceStoredAttachmentsWithCurrent(npcRef, store);
     }
 }

--- a/src/main/java/com/alechilles/alecstamework/npc/progression/CompanionAttachmentStateService.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/progression/CompanionAttachmentStateService.java
@@ -43,6 +43,31 @@ public final class CompanionAttachmentStateService {
         );
     }
 
+    public static void replaceStoredAttachmentsWithCurrent(@Nullable Ref<EntityStore> npcRef,
+                                                           @Nullable Store<EntityStore> store) {
+        if (npcRef == null || !npcRef.isValid() || store == null) {
+            return;
+        }
+        ComponentType<EntityStore, TameworkAttachmentsComponent> type = TameworkAttachmentsComponent.getComponentType();
+        if (type == null) {
+            return;
+        }
+
+        Map<String, String> current = resolveCurrentSupportedSelections(npcRef, store);
+        if (current.isEmpty()) {
+            return;
+        }
+        TameworkAttachmentsComponent persisted = store.getComponent(npcRef, type);
+        if (persisted != null && current.equals(persisted.getAttachmentIds())) {
+            return;
+        }
+        store.putComponent(
+                npcRef,
+                type,
+                new TameworkAttachmentsComponent(persisted != null ? persisted.getConfigId() : null, current)
+        );
+    }
+
     public static void syncStoredAttachments(@Nullable Ref<EntityStore> npcRef,
                                              @Nullable Store<EntityStore> store) {
         if (npcRef == null || !npcRef.isValid() || store == null) {

--- a/src/test/java/com/alechilles/alecstamework/commands/TameworkDeleteSpawnMarkerCommandSupportTest.java
+++ b/src/test/java/com/alechilles/alecstamework/commands/TameworkDeleteSpawnMarkerCommandSupportTest.java
@@ -1,0 +1,109 @@
+package com.alechilles.alecstamework.commands;
+
+import com.hypixel.hytale.math.vector.Vector3d;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class TameworkDeleteSpawnMarkerCommandSupportTest {
+
+    @Test
+    void parseUsesDefaultRangeWhenNoArgumentProvided() {
+        TameworkDeleteSpawnMarkerCommandSupport.ParseResult result =
+                TameworkDeleteSpawnMarkerCommandSupport.parse("tw deletespawnmarker");
+
+        assertEquals(TameworkDeleteSpawnMarkerCommandSupport.Mode.DELETE, result.mode());
+        assertEquals(10.0, result.range());
+    }
+
+    @Test
+    void parseClampsRangeToSupportedLimit() {
+        TameworkDeleteSpawnMarkerCommandSupport.ParseResult result =
+                TameworkDeleteSpawnMarkerCommandSupport.parse("tw deletespawnmarker 999");
+
+        assertEquals(TameworkDeleteSpawnMarkerCommandSupport.Mode.DELETE, result.mode());
+        assertEquals(64.0, result.range());
+    }
+
+    @Test
+    void parseRejectsInvalidRange() {
+        TameworkDeleteSpawnMarkerCommandSupport.ParseResult result =
+                TameworkDeleteSpawnMarkerCommandSupport.parse("tw deletespawnmarker near");
+
+        assertEquals(TameworkDeleteSpawnMarkerCommandSupport.Mode.INVALID, result.mode());
+    }
+
+    @Test
+    void scoringAcceptsMarkerCenteredInFrontOfPlayer() {
+        TameworkDeleteSpawnMarkerCommandSupport.TargetScore score =
+                TameworkDeleteSpawnMarkerCommandSupport.scoreCandidate(
+                        new Vector3d(0.0, 0.0, 0.0),
+                        new Vector3d(0.0, 0.0, 1.0),
+                        new Vector3d(0.1, 0.0, 6.0),
+                        10.0
+                );
+
+        assertTrue(score.matches());
+        assertEquals(6.0, score.forwardDistance(), 0.001);
+        assertEquals(0.1, score.perpendicularDistance(), 0.001);
+    }
+
+    @Test
+    void scoringRejectsMarkerBehindPlayer() {
+        TameworkDeleteSpawnMarkerCommandSupport.TargetScore score =
+                TameworkDeleteSpawnMarkerCommandSupport.scoreCandidate(
+                        new Vector3d(0.0, 0.0, 0.0),
+                        new Vector3d(0.0, 0.0, 1.0),
+                        new Vector3d(0.0, 0.0, -2.0),
+                        10.0
+                );
+
+        assertFalse(score.matches());
+    }
+
+    @Test
+    void scoringRejectsMarkerTooFarFromViewRay() {
+        TameworkDeleteSpawnMarkerCommandSupport.TargetScore score =
+                TameworkDeleteSpawnMarkerCommandSupport.scoreCandidate(
+                        new Vector3d(0.0, 0.0, 0.0),
+                        new Vector3d(0.0, 0.0, 1.0),
+                        new Vector3d(4.0, 0.0, 6.0),
+                        10.0
+                );
+
+        assertFalse(score.matches());
+    }
+
+    @Test
+    void betterScorePrefersCenteredMarkerOverCloserOffAxisMarker() {
+        TameworkDeleteSpawnMarkerCommandSupport.TargetScore centered =
+                TameworkDeleteSpawnMarkerCommandSupport.scoreCandidate(
+                        new Vector3d(0.0, 0.0, 0.0),
+                        new Vector3d(0.0, 0.0, 1.0),
+                        new Vector3d(0.05, 0.0, 7.0),
+                        10.0
+                );
+        TameworkDeleteSpawnMarkerCommandSupport.TargetScore offAxis =
+                TameworkDeleteSpawnMarkerCommandSupport.scoreCandidate(
+                        new Vector3d(0.0, 0.0, 0.0),
+                        new Vector3d(0.0, 0.0, 1.0),
+                        new Vector3d(1.0, 0.0, 4.0),
+                        10.0
+                );
+
+        assertTrue(centered.isBetterThan(offAxis));
+    }
+
+    @Test
+    void scoringRejectsInvalidForwardVector() {
+        assertNull(TameworkDeleteSpawnMarkerCommandSupport.scoreCandidate(
+                new Vector3d(0.0, 0.0, 0.0),
+                new Vector3d(0.0, 0.0, 0.0),
+                new Vector3d(0.0, 0.0, 4.0),
+                10.0
+        ));
+    }
+}

--- a/src/test/java/com/alechilles/alecstamework/commands/TameworkShowSpawnMarkersCommandSupportTest.java
+++ b/src/test/java/com/alechilles/alecstamework/commands/TameworkShowSpawnMarkersCommandSupportTest.java
@@ -1,0 +1,77 @@
+package com.alechilles.alecstamework.commands;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class TameworkShowSpawnMarkersCommandSupportTest {
+
+    @Test
+    void parseModeUsesDefaultRadiusWhenNoArgumentProvided() {
+        TameworkShowSpawnMarkersCommandSupport.ParseResult result =
+                TameworkShowSpawnMarkersCommandSupport.parse("tw showspawnmarkers");
+
+        assertEquals(TameworkShowSpawnMarkersCommandSupport.Mode.SHOW, result.mode());
+        assertEquals(64.0, result.radius());
+    }
+
+    @Test
+    void parseModeCanDisableTracking() {
+        TameworkShowSpawnMarkersCommandSupport.ParseResult result =
+                TameworkShowSpawnMarkersCommandSupport.parse("tw showspawnmarkers off");
+
+        assertEquals(TameworkShowSpawnMarkersCommandSupport.Mode.OFF, result.mode());
+    }
+
+    @Test
+    void parseModeClampsRadiusToSupportedRange() {
+        TameworkShowSpawnMarkersCommandSupport.ParseResult result =
+                TameworkShowSpawnMarkersCommandSupport.parse("tw showspawnmarkers 999");
+
+        assertEquals(TameworkShowSpawnMarkersCommandSupport.Mode.SHOW, result.mode());
+        assertEquals(256.0, result.radius());
+    }
+
+    @Test
+    void parseModeReportsInvalidRadius() {
+        TameworkShowSpawnMarkersCommandSupport.ParseResult result =
+                TameworkShowSpawnMarkersCommandSupport.parse("tw showspawnmarkers nearby");
+
+        assertEquals(TameworkShowSpawnMarkersCommandSupport.Mode.INVALID, result.mode());
+    }
+
+    @Test
+    void debugStyleUsesBrightPinkAndChunkierMarkerGeometry() {
+        TameworkShowSpawnMarkersCommandSupport.DebugStyle style =
+                TameworkShowSpawnMarkersCommandSupport.debugStyle();
+
+        assertEquals(1.0F, style.red());
+        assertEquals(0.05F, style.green());
+        assertEquals(0.85F, style.blue());
+        assertEquals(0.75, style.markerWidth());
+        assertEquals(1.2, style.capWidth());
+        assertEquals(0.95F, style.markerAlpha());
+    }
+
+    @Test
+    void formatNpcSummaryShowsSeveralWeightedNpcOptions() {
+        assertEquals(
+                "cow, chicken, fox",
+                TameworkShowSpawnMarkersCommandSupport.formatNpcSummary(
+                        java.util.List.of("cow", "chicken", "fox"),
+                        4
+                )
+        );
+    }
+
+    @Test
+    void formatNpcSummaryCompactsLongWeightedNpcOptions() {
+        assertEquals(
+                "cow, chicken, fox, wolf, +1 more",
+                TameworkShowSpawnMarkersCommandSupport.formatNpcSummary(
+                        java.util.List.of("cow", "chicken", "fox", "wolf", "bear"),
+                        4
+                )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `/tw showspawnmarkers [radius|off]` for player-local bright-pink spawn marker debug rendering and marker summaries.
- Add `/tw deletespawnmarker [range]` to delete the closest loaded spawn marker in the player's view path and clear block-backed marker state when available.
- Preserve explicit `/tw npcspawntamed` attachment overrides by replacing stored attachment state after spawner attachment application.

## Validation
- `git diff --check`
- `./mvnw.cmd test` - 481 tests passed

## Notes
- The new marker commands are registered under `/tw` and documented in the actions/sensors/components command list.
- The PR is opened as a draft for review.