### PR TITLE
Feat: Add breeding gender support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added `/tw showspawnmarkers [radius|off]` to render nearby loaded Hytale spawn markers with bright-pink player-local debug shapes and print marker IDs, NPC options, positions, spawn counts, manual-trigger status, and suppression state.
 - Added `/tw deletespawnmarker [range]` to delete the closest loaded spawn marker in the player's view path, clear the source block marker component when available, and report the marker ID, NPC options, and position.
+- Added optional gender support to `TwBreedingConfig` so modders can require male/female breeding pairs, preserve gender through growth/spawner metadata, show gender in linked panels and spawner tooltips, and use gender-aware random name pools.
 
 ### Fixed
 - Fixed `/tw npcspawntamed` attachment overrides being replaced by the NPC's initial random attachment choice after the sync system ran.

--- a/docs/Interactions.md
+++ b/docs/Interactions.md
@@ -123,6 +123,7 @@ Behavior:
 - Uses effective fertility: `(sharedHappiness * FertilityMultiplier) + FertilityBonus`.
 - When ready pair found: applies parent cooldown, pair movement, hearts, delayed offspring spawn.
 - Pairing can require the same role, require different adult roles in one lifecycle family, allow any adult in one lifecycle family, or explicitly allow any role through `TwBreedingConfig.Pairing.RoleCompatibility`.
+- If `TwBreedingConfig.Gender.Enabled` and `RequireDifferentGender` are enabled, partner selection also requires one male and one female companion.
 - Offspring flow supports baby-role preference, persisted weighted adult-role selection, life-stage initialization, trait/attachment inheritance, and growth timing.
 
 ## Custom interactions

--- a/src/main/java/com/alechilles/alecstamework/api/ProgressionView.java
+++ b/src/main/java/com/alechilles/alecstamework/api/ProgressionView.java
@@ -87,7 +87,8 @@ public record ProgressionView(@Nullable String profileId,
                                 double adultScale,
                                 @Nullable String adultRoleId,
                                 @Nullable String babyRoleId,
-                                @Nullable String adolescentRoleId) {
+                                @Nullable String adolescentRoleId,
+                                @Nullable String gender) {
     }
 
     public record TraitsView(@Nullable String configId,

--- a/src/main/java/com/alechilles/alecstamework/api/internal/ApiMapper.java
+++ b/src/main/java/com/alechilles/alecstamework/api/internal/ApiMapper.java
@@ -223,7 +223,8 @@ final class ApiMapper {
                 component != null ? component.getAdultScale() : 0.0,
                 component != null ? component.getAdultRoleId() : null,
                 component != null ? component.getBabyRoleId() : null,
-                component != null ? component.getAdolescentRoleId() : null
+                component != null ? component.getAdolescentRoleId() : null,
+                component != null ? component.getGender() : null
         );
     }
 

--- a/src/main/java/com/alechilles/alecstamework/config/TameworkMetadataKeys.java
+++ b/src/main/java/com/alechilles/alecstamework/config/TameworkMetadataKeys.java
@@ -48,6 +48,7 @@ public final class TameworkMetadataKeys {
     public static final String LIFE_STAGE_ADULT_SWITCH_SCALE = "Tamework.LifeStage.AdultSwitchScale";
     public static final String LIFE_STAGE_ADULT_SCALE = "Tamework.LifeStage.AdultScale";
     public static final String LIFE_STAGE_GROWTH_SCALING_ENABLED = "Tamework.LifeStage.GrowthScalingEnabled";
+    public static final String LIFE_STAGE_GENDER = "Tamework.LifeStage.Gender";
     public static final String NPC_NAME = "Tamework.NpcName";
     public static final String NPC_NAME_OWNER_UUID = "Tamework.NpcNameOwnerUuid";
     public static final String NPC_NAME_UPDATED_MS = "Tamework.NpcNameUpdatedMs";

--- a/src/main/java/com/alechilles/alecstamework/config/assets/TwBreedingConfig.java
+++ b/src/main/java/com/alechilles/alecstamework/config/assets/TwBreedingConfig.java
@@ -227,6 +227,40 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
         .add()
         .build();
 
+    private static final BuilderCodec<GenderSettings> GENDER_CODEC = BuilderCodec.builder(
+            GenderSettings.class,
+            GenderSettings::new
+    )
+        .<Boolean>append(
+            new KeyedCodec<>("Enabled", Codec.BOOLEAN),
+            (settings, value) -> settings.enabled = value != null && value,
+            settings -> settings.enabled
+        )
+        .documentation("Turns binary gender assignment and gender-aware breeding checks on or off.")
+        .add()
+        .<Boolean>append(
+            new KeyedCodec<>("RequireDifferentGender", Codec.BOOLEAN),
+            (settings, value) -> settings.requireDifferentGender = value == null || value,
+            settings -> settings.requireDifferentGender
+        )
+        .documentation("When gender is enabled, requires breeding partners to have different genders.")
+        .add()
+        .<Double>append(
+            new KeyedCodec<>("MaleWeight", Codec.DOUBLE),
+            (settings, value) -> settings.maleWeight = value,
+            settings -> settings.maleWeight
+        )
+        .documentation("Relative weighted chance for random male assignment.")
+        .add()
+        .<Double>append(
+            new KeyedCodec<>("FemaleWeight", Codec.DOUBLE),
+            (settings, value) -> settings.femaleWeight = value,
+            settings -> settings.femaleWeight
+        )
+        .documentation("Relative weighted chance for random female assignment.")
+        .add()
+        .build();
+
     private static final BuilderCodec<InheritanceSettings> INHERITANCE_CODEC = BuilderCodec.builder(
             InheritanceSettings.class,
             InheritanceSettings::new
@@ -319,6 +353,13 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
             choice -> choice.roleId
         )
         .documentation("Adult role ID that offspring can grow into.")
+        .add()
+        .<String>append(
+            new KeyedCodec<>("Gender", Codec.STRING),
+            (choice, value) -> choice.gender = Gender.fromConfigValue(value),
+            choice -> choice.gender == null ? null : choice.gender.toConfigValue()
+        )
+        .documentation("Optional binary gender for this adult role: Male or Female.")
         .add()
         .<Double>append(
             new KeyedCodec<>("Weight", Codec.DOUBLE),
@@ -737,6 +778,40 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
         .add()
         .build();
 
+    private static final BuilderCodec<GenderSettingsOverride> GENDER_OVERRIDE_CODEC = BuilderCodec.builder(
+            GenderSettingsOverride.class,
+            GenderSettingsOverride::new
+    )
+        .<Boolean>append(
+            new KeyedCodec<>("Enabled", Codec.BOOLEAN),
+            (settings, value) -> settings.enabled = value,
+            settings -> settings.enabled
+        )
+        .documentation("Turns binary gender assignment and gender-aware breeding checks on or off.")
+        .add()
+        .<Boolean>append(
+            new KeyedCodec<>("RequireDifferentGender", Codec.BOOLEAN),
+            (settings, value) -> settings.requireDifferentGender = value,
+            settings -> settings.requireDifferentGender
+        )
+        .documentation("When gender is enabled, requires breeding partners to have different genders.")
+        .add()
+        .<Double>append(
+            new KeyedCodec<>("MaleWeight", Codec.DOUBLE),
+            (settings, value) -> settings.maleWeight = value,
+            settings -> settings.maleWeight
+        )
+        .documentation("Relative weighted chance for random male assignment.")
+        .add()
+        .<Double>append(
+            new KeyedCodec<>("FemaleWeight", Codec.DOUBLE),
+            (settings, value) -> settings.femaleWeight = value,
+            settings -> settings.femaleWeight
+        )
+        .documentation("Relative weighted chance for random female assignment.")
+        .add()
+        .build();
+
     private static final BuilderCodec<AttachmentInheritanceSettingsOverride> ATTACHMENT_INHERITANCE_OVERRIDE_CODEC =
             BuilderCodec.builder(
                 AttachmentInheritanceSettingsOverride.class,
@@ -981,6 +1056,13 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
         )
         .documentation("Lifecycle timing and growth progression settings.")
         .add()
+        .<GenderSettingsOverride>append(
+            new KeyedCodec<>("Gender", GENDER_OVERRIDE_CODEC),
+            (settings, value) -> settings.gender = value,
+            settings -> settings.gender
+        )
+        .documentation("Optional binary gender settings for this role.")
+        .add()
         .<InheritanceSettingsOverride>append(
             new KeyedCodec<>("Inheritance", INHERITANCE_OVERRIDE_CODEC),
             (settings, value) -> settings.inheritance = value,
@@ -1080,6 +1162,14 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
         .documentation("Breeding timing settings. Inheritance: omitted section inherits from parent; when present, "
                 + "only explicitly defined nested fields override parent.")
         .add()
+        .<GenderSettings>append(
+            new KeyedCodec<>("Gender", GENDER_CODEC),
+            (asset, value) -> asset.gender = value == null ? new GenderSettings() : value,
+            asset -> asset.gender
+        )
+        .documentation("Optional binary gender settings. Inheritance: omitted section inherits from parent; when "
+                + "present, only explicitly defined nested fields override parent.")
+        .add()
         .<InheritanceSettings>append(
             new KeyedCodec<>("Inheritance", INHERITANCE_CODEC),
             (asset, value) -> asset.inheritance = value == null ? new InheritanceSettings() : value,
@@ -1125,6 +1215,7 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
     private CooldownSettings cooldowns = new CooldownSettings();
     private PassiveBreedingSettings passiveBreeding = new PassiveBreedingSettings();
     private TimingSettings timing = new TimingSettings();
+    private GenderSettings gender = new GenderSettings();
     private InheritanceSettings inheritance = new InheritanceSettings();
     private OffspringLifecycleSettings offspringLifecycle = new OffspringLifecycleSettings();
     private Map<String, RoleOverrideSettings> roleOverrides = EMPTY_ROLE_OVERRIDES;
@@ -1322,6 +1413,11 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
         } else {
             inheritTimingSection(parent, nestedKeysForTopLevel(explicitNestedKeysByTopLevel, "Timing"));
         }
+        if (!explicitTopLevelKeys.contains("Gender")) {
+            gender = parent.gender;
+        } else {
+            inheritGenderSection(parent, nestedKeysForTopLevel(explicitNestedKeysByTopLevel, "Gender"));
+        }
         if (!explicitTopLevelKeys.contains("Inheritance")) {
             inheritance = parent.inheritance;
         } else {
@@ -1466,6 +1562,25 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
             return;
         }
         if (!nestedExplicitKeys.contains("Basis")) timing.timerBasis = parent.timing.timerBasis;
+    }
+
+    private void inheritGenderSection(@Nonnull TwBreedingConfig parent, @Nullable Set<String> nestedExplicitKeys) {
+        if (nestedExplicitKeys == null) {
+            return;
+        }
+        if (gender == null) {
+            gender = parent.gender;
+            return;
+        }
+        if (parent.gender == null) {
+            return;
+        }
+        if (!nestedExplicitKeys.contains("Enabled")) gender.enabled = parent.gender.enabled;
+        if (!nestedExplicitKeys.contains("RequireDifferentGender")) {
+            gender.requireDifferentGender = parent.gender.requireDifferentGender;
+        }
+        if (!nestedExplicitKeys.contains("MaleWeight")) gender.maleWeight = parent.gender.maleWeight;
+        if (!nestedExplicitKeys.contains("FemaleWeight")) gender.femaleWeight = parent.gender.femaleWeight;
     }
 
     private void inheritInheritanceSection(@Nonnull TwBreedingConfig parent, @Nullable Set<String> nestedExplicitKeys) {
@@ -1761,6 +1876,20 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
         return resolved;
     }
 
+    public GenderSettings getGender() {
+        return gender == null ? new GenderSettings() : gender;
+    }
+
+    public GenderSettings resolveGender(@Nullable String roleId) {
+        RoleOverrideSettings override = resolveRoleOverride(roleId);
+        if (override == null || override.gender == null) {
+            return copyGender(getGender());
+        }
+        GenderSettings resolved = copyGender(getGender());
+        override.gender.applyTo(resolved);
+        return resolved;
+    }
+
     public InheritanceSettings getInheritance() {
         return inheritance == null ? new InheritanceSettings() : inheritance;
     }
@@ -1898,6 +2027,16 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
         return copy;
     }
 
+    private static GenderSettings copyGender(@Nullable GenderSettings source) {
+        GenderSettings base = source == null ? new GenderSettings() : source;
+        GenderSettings copy = new GenderSettings();
+        copy.enabled = base.enabled;
+        copy.requireDifferentGender = base.requireDifferentGender;
+        copy.maleWeight = base.maleWeight;
+        copy.femaleWeight = base.femaleWeight;
+        return copy;
+    }
+
     private static InheritanceSettings copyInheritance(@Nullable InheritanceSettings source) {
         InheritanceSettings base = source == null ? new InheritanceSettings() : source;
         InheritanceSettings copy = new InheritanceSettings();
@@ -1955,6 +2094,7 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
         private CooldownSettingsOverride cooldowns;
         private PassiveBreedingSettingsOverride passiveBreeding;
         private TimingSettingsOverride timing;
+        private GenderSettingsOverride gender;
         private InheritanceSettingsOverride inheritance;
         private OffspringLifecycleSettingsOverride offspringLifecycle;
     }
@@ -2073,6 +2213,29 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
         private void applyTo(@Nonnull TimingSettings target) {
             if (timerBasis != null) {
                 target.timerBasis = timerBasis;
+            }
+        }
+    }
+
+    /** Partial gender override patch for a single role. */
+    public static final class GenderSettingsOverride {
+        private Boolean enabled;
+        private Boolean requireDifferentGender;
+        private Double maleWeight;
+        private Double femaleWeight;
+
+        private void applyTo(@Nonnull GenderSettings target) {
+            if (enabled != null) {
+                target.enabled = enabled;
+            }
+            if (requireDifferentGender != null) {
+                target.requireDifferentGender = requireDifferentGender;
+            }
+            if (maleWeight != null) {
+                target.maleWeight = maleWeight;
+            }
+            if (femaleWeight != null) {
+                target.femaleWeight = femaleWeight;
             }
         }
     }
@@ -2456,6 +2619,81 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
         }
     }
 
+    /** Binary gender values used by optional breeding gender support. */
+    public enum Gender {
+        Male,
+        Female;
+
+        @Nullable
+        public static Gender fromConfigValue(@Nullable String value) {
+            if (value == null || value.isBlank()) {
+                return null;
+            }
+            for (Gender candidate : values()) {
+                if (candidate.name().equalsIgnoreCase(value.trim())) {
+                    return candidate;
+                }
+            }
+            return null;
+        }
+
+        public String toConfigValue() {
+            return name();
+        }
+    }
+
+    /** Optional binary gender assignment and pairing settings. */
+    public static final class GenderSettings {
+        private boolean enabled;
+        private boolean requireDifferentGender = true;
+        private double maleWeight = 1.0;
+        private double femaleWeight = 1.0;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public boolean isRequireDifferentGender() {
+            return requireDifferentGender;
+        }
+
+        public double getMaleWeight() {
+            return sanitizeWeight(maleWeight, 1.0);
+        }
+
+        public double getFemaleWeight() {
+            return sanitizeWeight(femaleWeight, 1.0);
+        }
+
+        public Gender selectGender(double roll) {
+            double male = getMaleWeight();
+            double female = getFemaleWeight();
+            double total = male + female;
+            if (!Double.isFinite(total) || total <= 0.0) {
+                return Gender.Male;
+            }
+            double target = clampRoll(roll) * total;
+            return target < male ? Gender.Male : Gender.Female;
+        }
+
+        private static double sanitizeWeight(double value, double fallback) {
+            if (!Double.isFinite(value) || value < 0.0) {
+                return fallback;
+            }
+            return value;
+        }
+
+        private static double clampRoll(double roll) {
+            if (!Double.isFinite(roll) || roll <= 0.0) {
+                return 0.0;
+            }
+            if (roll >= 1.0) {
+                return Math.nextDown(1.0);
+            }
+            return roll;
+        }
+    }
+
     /** Lifecycle role family mappings and growth defaults used for offspring progression. */
     public static final class OffspringLifecycleSettings {
         private static final int MIN_TIME_TO_FULL_GROWN_SECONDS = 1;
@@ -2584,11 +2822,17 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
     /** Weighted adult role option for multi-adult breeding families. */
     public static final class AdultRoleChoice {
         private String roleId;
+        private Gender gender;
         private double weight = 1.0;
 
         @Nullable
         public String getRoleId() {
             return roleId;
+        }
+
+        @Nullable
+        public Gender getGender() {
+            return gender;
         }
 
         public double getWeight() {
@@ -2604,6 +2848,10 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
 
         public boolean matchesRole(@Nullable String targetRoleId) {
             return RoleFamily.matchesRoleId(roleId, targetRoleId);
+        }
+
+        public boolean matchesGender(@Nullable Gender targetGender) {
+            return targetGender == null || gender == null || gender == targetGender;
         }
     }
 
@@ -2716,6 +2964,19 @@ public final class TwBreedingConfig implements JsonAssetWithMap<String, DefaultA
                 return false;
             }
             return adultRoleId != null && !adultRoleId.isBlank();
+        }
+
+        @Nullable
+        public Gender resolveGenderForAdultRole(@Nullable String roleId) {
+            if (roleId == null || roleId.isBlank()) {
+                return null;
+            }
+            for (AdultRoleChoice choice : getAdultRoles()) {
+                if (choice != null && choice.matchesRole(roleId)) {
+                    return choice.getGender();
+                }
+            }
+            return null;
         }
 
         @Nullable

--- a/src/main/java/com/alechilles/alecstamework/config/assets/TwNamesConfig.java
+++ b/src/main/java/com/alechilles/alecstamework/config/assets/TwNamesConfig.java
@@ -134,6 +134,11 @@ public class TwNamesConfig implements JsonAssetWithMap<String, DefaultAssetMap<S
 
     @Nonnull
     public static String[] resolveMergedPoolById(@Nullable String id) {
+        return resolveMergedPoolById(id, null);
+    }
+
+    @Nonnull
+    public static String[] resolveMergedPoolById(@Nullable String id, @Nullable String gender) {
         if (id == null || id.isBlank()) {
             return new String[0];
         }
@@ -145,7 +150,7 @@ public class TwNamesConfig implements JsonAssetWithMap<String, DefaultAssetMap<S
         if (asset == null) {
             return new String[0];
         }
-        return asset.getMergedPool();
+        return asset.getMergedPool(gender);
     }
 
     private static void ensureInheritanceFallbackApplied(@Nullable DefaultAssetMap<String, TwNamesConfig> assetMap) {
@@ -243,17 +248,28 @@ public class TwNamesConfig implements JsonAssetWithMap<String, DefaultAssetMap<S
 
     @Nonnull
     public String[] getMergedPool() {
+        return getMergedPool(null);
+    }
+
+    @Nonnull
+    public String[] getMergedPool(@Nullable String gender) {
         ArrayList<String> out = new ArrayList<>();
         HashSet<String> seen = new HashSet<>();
-        appendUnique(out, seen, northAmericaMale);
-        appendUnique(out, seen, northAmericaFemale);
-        appendUnique(out, seen, germanMale);
-        appendUnique(out, seen, germanFemale);
-        appendUnique(out, seen, spanishMale);
-        appendUnique(out, seen, spanishFemale);
-        appendUnique(out, seen, brazilianPortugueseMale);
-        appendUnique(out, seen, brazilianPortugueseFemale);
+        boolean maleOnly = isGender(gender, "Male");
+        boolean femaleOnly = isGender(gender, "Female");
+        if (!femaleOnly) appendUnique(out, seen, northAmericaMale);
+        if (!maleOnly) appendUnique(out, seen, northAmericaFemale);
+        if (!femaleOnly) appendUnique(out, seen, germanMale);
+        if (!maleOnly) appendUnique(out, seen, germanFemale);
+        if (!femaleOnly) appendUnique(out, seen, spanishMale);
+        if (!maleOnly) appendUnique(out, seen, spanishFemale);
+        if (!femaleOnly) appendUnique(out, seen, brazilianPortugueseMale);
+        if (!maleOnly) appendUnique(out, seen, brazilianPortugueseFemale);
         return out.toArray(String[]::new);
+    }
+
+    private static boolean isGender(@Nullable String value, @Nonnull String expected) {
+        return value != null && expected.equalsIgnoreCase(value.trim());
     }
 
     private static void appendUnique(@Nonnull ArrayList<String> out, @Nonnull HashSet<String> seen, @Nullable String[] values) {

--- a/src/main/java/com/alechilles/alecstamework/integration/tooltips/TameworkSpawnerTooltipProvider.java
+++ b/src/main/java/com/alechilles/alecstamework/integration/tooltips/TameworkSpawnerTooltipProvider.java
@@ -22,6 +22,7 @@ final class TameworkSpawnerTooltipProvider implements TooltipProvider {
     private static final String GENERIC_CAPTURE_CRATE_KEY = "server.items.captureCrate.name";
     private static final String NAME_LINE_PREFIX = "Name: ";
     private static final String ROLE_LINE_PREFIX = "Role: ";
+    private static final String GENDER_LINE_PREFIX = "Gender: ";
 
     private final ItemFeatureRegistry itemFeatureRegistry;
     private final TranslationRegistry translationRegistry;
@@ -80,12 +81,17 @@ final class TameworkSpawnerTooltipProvider implements TooltipProvider {
             mode = ItemFeatureConfig.SpawnerTooltipMode.ADDITIVE;
         }
 
+        String gender = readString(metadataDoc, TameworkMetadataKeys.LIFE_STAGE_GENDER);
         TooltipData.Builder builder = TooltipData.builder()
                 .nameOverride(itemName)
-                .hashInput((mode.name()) + "|" + itemName + "|" + displayName + "|" + (roleDisplay == null ? "" : roleDisplay));
+                .hashInput((mode.name()) + "|" + itemName + "|" + displayName + "|"
+                        + (roleDisplay == null ? "" : roleDisplay) + "|" + (gender == null ? "" : gender));
         appendLine(builder, mode, NAME_LINE_PREFIX + displayName);
         if (roleDisplay != null && !roleDisplay.isBlank()) {
             appendLine(builder, mode, ROLE_LINE_PREFIX + roleDisplay);
+        }
+        if (gender != null && !gender.isBlank()) {
+            appendLine(builder, mode, GENDER_LINE_PREFIX + gender);
         }
         TooltipData data = builder.build();
         return data.isEmpty() ? null : data;

--- a/src/main/java/com/alechilles/alecstamework/items/CommandLinkedPanelEntryService.java
+++ b/src/main/java/com/alechilles/alecstamework/items/CommandLinkedPanelEntryService.java
@@ -15,6 +15,7 @@ import com.alechilles.alecstamework.npc.progression.BreedingTimeService;
 import com.alechilles.alecstamework.npc.progression.CompanionRoleIdResolver;
 import com.alechilles.alecstamework.npc.progression.CompanionHappinessModifierService;
 import com.alechilles.alecstamework.npc.progression.CompanionHappinessService;
+import com.alechilles.alecstamework.npc.progression.CompanionGenderService;
 import com.alechilles.alecstamework.npc.progression.CompanionLevelingService;
 import com.alechilles.alecstamework.npc.progression.CompanionTalentService;
 import com.alechilles.alecstamework.npc.progression.NeedsConfigResolver;
@@ -154,6 +155,11 @@ final class CommandLinkedPanelEntryService {
                             speciesId = resolvedRoleId;
                             speciesLabel = resolvedRoleId;
                         }
+                        displayName = appendGenderLabel(
+                                displayName,
+                                CompanionGenderService.resolveGender(npcRef, store, resolvedRoleId, null),
+                                playerLanguage
+                        );
                         TameworkCommandLinksComponent links =
                                 safeGetComponent(store, npcRef, TameworkCommandLinksComponent.getComponentType());
                         if (links != null && links.hasHome()) {
@@ -342,6 +348,19 @@ final class CommandLinkedPanelEntryService {
                                                                  @Nullable String language) {
         String label = LocalizedText.resolve(language, "tamework.ui.linkedPanel.futureStat.talentPoints");
         return new LinkedNpcEntry.FutureStat(label, Math.max(0, availablePoints), Math.max(1, totalEarnedPoints));
+    }
+
+    private String appendGenderLabel(@Nullable String displayName,
+                                     @Nullable String gender,
+                                     @Nullable String language) {
+        String baseName = displayName == null || displayName.isBlank()
+                ? LocalizedText.resolve(language, "tamework.ui.linkedPanel.subtitle.defaultNpcName")
+                : displayName;
+        String label = CompanionGenderService.toDisplayLabel(gender);
+        if (label == null || label.isBlank()) {
+            return baseName;
+        }
+        return baseName + " (" + label + ")";
     }
 
     @Nullable

--- a/src/main/java/com/alechilles/alecstamework/items/NamingFeatureHandler.java
+++ b/src/main/java/com/alechilles/alecstamework/items/NamingFeatureHandler.java
@@ -8,6 +8,7 @@ import com.alechilles.alecstamework.localization.LocalizedText;
 import com.alechilles.alecstamework.localization.TranslationRegistry;
 import com.alechilles.alecstamework.metrics.TameworkTelemetryEvents;
 import com.alechilles.alecstamework.npc.components.TameworkNpcNameComponent;
+import com.alechilles.alecstamework.npc.progression.CompanionGenderService;
 import com.alechilles.alecstamework.ownership.OwnerMessageUtil;
 import com.alechilles.alecstamework.ui.TameworkNameInputPage;
 import com.hypixel.hytale.codec.Codec;
@@ -124,7 +125,8 @@ public final class NamingFeatureHandler {
         if (playerUuid == null) {
             return false;
         }
-        String[] randomNamePool = resolveRandomNamePool(config);
+        String gender = CompanionGenderService.resolveGender(targetRef, store, roleId, null);
+        String[] randomNamePool = resolveRandomNamePool(config, gender);
         PendingNameRequest uiRequest = new PendingNameRequest(
                 playerUuid,
                 targetRef,
@@ -522,6 +524,11 @@ public final class NamingFeatureHandler {
 
     @Nonnull
     private String[] resolveRandomNamePool(@Nullable TwNameItemConfig config) {
+        return resolveRandomNamePool(config, null);
+    }
+
+    @Nonnull
+    private String[] resolveRandomNamePool(@Nullable TwNameItemConfig config, @Nullable String gender) {
         if (config == null || config.getNaming() == null) {
             return EMPTY_RANDOM_NAME_POOL;
         }
@@ -529,7 +536,7 @@ public final class NamingFeatureHandler {
         if (randomNamesId == null || randomNamesId.isBlank()) {
             return EMPTY_RANDOM_NAME_POOL;
         }
-        String[] resolved = TwNamesConfig.resolveMergedPoolById(randomNamesId);
+        String[] resolved = TwNamesConfig.resolveMergedPoolById(randomNamesId, gender);
         if (resolved.length == 0) {
             return EMPTY_RANDOM_NAME_POOL;
         }

--- a/src/main/java/com/alechilles/alecstamework/items/SpawnerNpcProgressionMetadataService.java
+++ b/src/main/java/com/alechilles/alecstamework/items/SpawnerNpcProgressionMetadataService.java
@@ -92,6 +92,7 @@ final class SpawnerNpcProgressionMetadataService {
         updated = clearMetadataKey(updated, TameworkMetadataKeys.LIFE_STAGE_ADULT_SWITCH_SCALE);
         updated = clearMetadataKey(updated, TameworkMetadataKeys.LIFE_STAGE_ADULT_SCALE);
         updated = clearMetadataKey(updated, TameworkMetadataKeys.LIFE_STAGE_GROWTH_SCALING_ENABLED);
+        updated = clearMetadataKey(updated, TameworkMetadataKeys.LIFE_STAGE_GENDER);
         return updated;
     }
 
@@ -648,6 +649,7 @@ final class SpawnerNpcProgressionMetadataService {
             updated = clearMetadataKey(updated, TameworkMetadataKeys.LIFE_STAGE_ADULT_SWITCH_SCALE);
             updated = clearMetadataKey(updated, TameworkMetadataKeys.LIFE_STAGE_ADULT_SCALE);
             updated = clearMetadataKey(updated, TameworkMetadataKeys.LIFE_STAGE_GROWTH_SCALING_ENABLED);
+            updated = clearMetadataKey(updated, TameworkMetadataKeys.LIFE_STAGE_GENDER);
             return updated;
         }
         ItemStack updated = stack;
@@ -699,6 +701,11 @@ final class SpawnerNpcProgressionMetadataService {
                 Codec.BOOLEAN,
                 component.isGrowthScalingEnabled()
         );
+        if (component.getGender() != null && !component.getGender().isBlank()) {
+            updated = updated.withMetadata(TameworkMetadataKeys.LIFE_STAGE_GENDER, Codec.STRING, component.getGender());
+        } else {
+            updated = clearMetadataKey(updated, TameworkMetadataKeys.LIFE_STAGE_GENDER);
+        }
         return updated;
     }
 
@@ -730,6 +737,7 @@ final class SpawnerNpcProgressionMetadataService {
                 TameworkMetadataKeys.LIFE_STAGE_GROWTH_SCALING_ENABLED,
                 Codec.BOOLEAN
         );
+        String gender = stack.getFromMetadataOrNull(TameworkMetadataKeys.LIFE_STAGE_GENDER, Codec.STRING);
         boolean hasData = (stage != null && !stage.isBlank())
                 || bornAtMs != null
                 || adolescentAtMs != null
@@ -741,7 +749,8 @@ final class SpawnerNpcProgressionMetadataService {
                 || adultStartScale != null
                 || adultSwitchScale != null
                 || adultScale != null
-                || growthScaling != null;
+                || growthScaling != null
+                || (gender != null && !gender.isBlank());
         if (!hasData) {
             return;
         }
@@ -784,6 +793,12 @@ final class SpawnerNpcProgressionMetadataService {
                         ? growthScaling
                         : existing != null && existing.isGrowthScalingEnabled()
         );
+        restored.setAdultRoleId(existing != null ? existing.getAdultRoleId() : null);
+        restored.setBabyRoleId(existing != null ? existing.getBabyRoleId() : null);
+        restored.setAdolescentRoleId(existing != null ? existing.getAdolescentRoleId() : null);
+        restored.setGender(gender != null && !gender.isBlank()
+                ? gender
+                : existing != null ? existing.getGender() : null);
         store.putComponent(npcRef, type, restored);
     }
 

--- a/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingAdultRoleSelectionService.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingAdultRoleSelectionService.java
@@ -11,13 +11,21 @@ import javax.annotation.Nullable;
 final class BreedingAdultRoleSelectionService {
     @Nullable
     String selectAdultRole(@Nullable TwBreedingConfig.RoleFamily family, @Nullable NPCPlugin npcPlugin) {
-        return selectAdultRole(family, npcPlugin, ThreadLocalRandom.current().nextDouble());
+        return selectAdultRole(family, npcPlugin, ThreadLocalRandom.current().nextDouble(), null);
     }
 
     @Nullable
     String selectAdultRole(@Nullable TwBreedingConfig.RoleFamily family,
                            @Nullable NPCPlugin npcPlugin,
                            double roll) {
+        return selectAdultRole(family, npcPlugin, roll, null);
+    }
+
+    @Nullable
+    String selectAdultRole(@Nullable TwBreedingConfig.RoleFamily family,
+                           @Nullable NPCPlugin npcPlugin,
+                           double roll,
+                           @Nullable TwBreedingConfig.Gender gender) {
         if (family == null) {
             return null;
         }
@@ -27,12 +35,11 @@ final class BreedingAdultRoleSelectionService {
                     : null;
         }
 
-        double totalWeight = 0.0;
-        for (TwBreedingConfig.AdultRoleChoice choice : family.getAdultRoles()) {
-            if (choice == null || !isAvailableRole(choice.getRoleId(), npcPlugin)) {
-                continue;
-            }
-            totalWeight += choice.getWeight();
+        double totalWeight = totalWeight(family, npcPlugin, gender);
+        TwBreedingConfig.Gender effectiveGender = gender;
+        if (!Double.isFinite(totalWeight) || totalWeight <= 0.0) {
+            effectiveGender = null;
+            totalWeight = totalWeight(family, npcPlugin, null);
         }
         if (!Double.isFinite(totalWeight) || totalWeight <= 0.0) {
             return null;
@@ -42,7 +49,7 @@ final class BreedingAdultRoleSelectionService {
         double cursor = 0.0;
         String fallback = null;
         for (TwBreedingConfig.AdultRoleChoice choice : family.getAdultRoles()) {
-            if (choice == null || !isAvailableRole(choice.getRoleId(), npcPlugin)) {
+            if (choice == null || !isAvailableRole(choice.getRoleId(), npcPlugin) || !choice.matchesGender(effectiveGender)) {
                 continue;
             }
             double weight = choice.getWeight();
@@ -56,6 +63,26 @@ final class BreedingAdultRoleSelectionService {
             }
         }
         return fallback;
+    }
+
+    private static double totalWeight(@Nullable TwBreedingConfig.RoleFamily family,
+                                      @Nullable NPCPlugin npcPlugin,
+                                      @Nullable TwBreedingConfig.Gender gender) {
+        if (family == null) {
+            return 0.0;
+        }
+        double totalWeight = 0.0;
+        for (TwBreedingConfig.AdultRoleChoice choice : family.getAdultRoles()) {
+            if (choice == null || !isAvailableRole(choice.getRoleId(), npcPlugin) || !choice.matchesGender(gender)) {
+                continue;
+            }
+            double weight = choice.getWeight();
+            if (weight <= 0.0) {
+                continue;
+            }
+            totalWeight += weight;
+        }
+        return totalWeight;
     }
 
     private static boolean isAvailableRole(@Nullable String roleId, @Nullable NPCPlugin npcPlugin) {

--- a/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringProgressionService.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringProgressionService.java
@@ -12,6 +12,7 @@ import com.alechilles.alecstamework.npc.components.TameworkTamedComponent;
 import com.alechilles.alecstamework.npc.components.TameworkTraitsComponent;
 import com.alechilles.alecstamework.npc.progression.CompanionAttachmentInheritanceService;
 import com.alechilles.alecstamework.npc.progression.BreedingTimeService;
+import com.alechilles.alecstamework.npc.progression.CompanionGenderService;
 import com.alechilles.alecstamework.npc.progression.CompanionModelAttachmentService;
 import com.alechilles.alecstamework.npc.progression.CompanionProgressionBootstrapService;
 import com.alechilles.alecstamework.npc.progression.CompanionLifeStageService;
@@ -62,6 +63,7 @@ final class BreedingOffspringProgressionService {
                              @Nullable String breedingConfigId,
                              long childCooldownMs,
                              @Nullable String selectedAdultRoleId,
+                             @Nullable TwBreedingConfig.Gender selectedGender,
                              @Nullable TwBreedingConfig.RoleFamily lifecycleFamily,
                              Store<EntityStore> store) {
         if (childRef == null || !childRef.isValid() || store == null || childRoleId == null || childRoleId.isBlank()) {
@@ -103,6 +105,7 @@ final class BreedingOffspringProgressionService {
                 selectedAdultRoleId,
                 lifecycleFamily
         );
+        CompanionGenderService.ensureGender(childRef, store, childRoleId, breedingConfig, selectedGender);
         CompanionLifeStageService.refreshLifeStage(childRef, childNpc, store);
         applyOffspringBreedingLock(childRef, childNpc, childCooldownMs, store);
         boolean familyAssigned = familyFlockService.assignFamilyFlock(childRef, parentARef, parentBRef, store);

--- a/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringRoleResolver.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringRoleResolver.java
@@ -14,7 +14,7 @@ final class BreedingOffspringRoleResolver {
     OffspringRoleSelection selectOffspringRole(@Nullable String parentRoleId,
                                                @Nullable TwBreedingConfig breedingConfig,
                                                @Nullable NPCPlugin npcPlugin) {
-        return selectOffspringRole(parentRoleId, breedingConfig, npcPlugin, Math.random());
+        return selectOffspringRole(parentRoleId, breedingConfig, npcPlugin, Math.random(), Math.random());
     }
 
     @Nullable
@@ -22,6 +22,15 @@ final class BreedingOffspringRoleResolver {
                                                @Nullable TwBreedingConfig breedingConfig,
                                                @Nullable NPCPlugin npcPlugin,
                                                double adultRoleRoll) {
+        return selectOffspringRole(parentRoleId, breedingConfig, npcPlugin, adultRoleRoll, Math.random());
+    }
+
+    @Nullable
+    OffspringRoleSelection selectOffspringRole(@Nullable String parentRoleId,
+                                               @Nullable TwBreedingConfig breedingConfig,
+                                               @Nullable NPCPlugin npcPlugin,
+                                               double adultRoleRoll,
+                                               double genderRoll) {
         if (parentRoleId == null || parentRoleId.isBlank() || npcPlugin == null) {
             return null;
         }
@@ -32,26 +41,46 @@ final class BreedingOffspringRoleResolver {
             if (lifecycle != null && lifecycle.isEnabled()) {
                 TwBreedingConfig.RoleFamily family = breedingConfig.resolveLifecycleFamilyForRole(parentRoleId);
                 if (family != null) {
-                    String adultRoleId = adultRoleSelectionService.selectAdultRole(family, npcPlugin, adultRoleRoll);
+                    TwBreedingConfig.Gender gender = resolveOffspringGender(parentRoleId, breedingConfig, genderRoll);
+                    String adultRoleId = adultRoleSelectionService.selectAdultRole(
+                            family,
+                            npcPlugin,
+                            adultRoleRoll,
+                            gender
+                    );
                     if (adultRoleId == null || adultRoleId.isBlank()) {
                         return null;
                     }
                     String babyRoleId = family.getBabyRoleId();
                     if (babyRoleId != null && !babyRoleId.isBlank() && npcPlugin.getIndex(babyRoleId) >= 0) {
-                        return new OffspringRoleSelection(babyRoleId, adultRoleId, family);
+                        return new OffspringRoleSelection(babyRoleId, adultRoleId, gender, family);
                     }
-                    return new OffspringRoleSelection(adultRoleId, adultRoleId, family);
+                    return new OffspringRoleSelection(adultRoleId, adultRoleId, gender, family);
                 }
             }
         }
         if (npcPlugin.getIndex(parentRoleId) >= 0) {
-            return new OffspringRoleSelection(parentRoleId, parentRoleId, null);
+            return new OffspringRoleSelection(parentRoleId, parentRoleId, null, null);
         }
         return null;
     }
 
+    @Nullable
+    private static TwBreedingConfig.Gender resolveOffspringGender(@Nullable String parentRoleId,
+                                                                  @Nullable TwBreedingConfig breedingConfig,
+                                                                  double genderRoll) {
+        TwBreedingConfig.GenderSettings settings = breedingConfig != null
+                ? breedingConfig.resolveGender(parentRoleId)
+                : null;
+        if (settings == null || !settings.isEnabled()) {
+            return null;
+        }
+        return settings.selectGender(genderRoll);
+    }
+
     record OffspringRoleSelection(String roleId,
                                   String adultRoleId,
+                                  @Nullable TwBreedingConfig.Gender gender,
                                   @Nullable TwBreedingConfig.RoleFamily lifecycleFamily) {
     }
 }

--- a/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringRoleResolver.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringRoleResolver.java
@@ -51,11 +51,12 @@ final class BreedingOffspringRoleResolver {
                     if (adultRoleId == null || adultRoleId.isBlank()) {
                         return null;
                     }
+                    TwBreedingConfig.Gender selectedGender = resolveSelectedGender(family, adultRoleId, gender);
                     String babyRoleId = family.getBabyRoleId();
                     if (babyRoleId != null && !babyRoleId.isBlank() && npcPlugin.getIndex(babyRoleId) >= 0) {
-                        return new OffspringRoleSelection(babyRoleId, adultRoleId, gender, family);
+                        return new OffspringRoleSelection(babyRoleId, adultRoleId, selectedGender, family);
                     }
-                    return new OffspringRoleSelection(adultRoleId, adultRoleId, gender, family);
+                    return new OffspringRoleSelection(adultRoleId, adultRoleId, selectedGender, family);
                 }
             }
         }
@@ -76,6 +77,16 @@ final class BreedingOffspringRoleResolver {
             return null;
         }
         return settings.selectGender(genderRoll);
+    }
+
+    @Nullable
+    static TwBreedingConfig.Gender resolveSelectedGender(@Nullable TwBreedingConfig.RoleFamily family,
+                                                         @Nullable String adultRoleId,
+                                                         @Nullable TwBreedingConfig.Gender sampledGender) {
+        TwBreedingConfig.Gender adultRoleGender = family != null
+                ? family.resolveGenderForAdultRole(adultRoleId)
+                : null;
+        return adultRoleGender != null ? adultRoleGender : sampledGender;
     }
 
     record OffspringRoleSelection(String roleId,

--- a/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringService.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringService.java
@@ -816,6 +816,7 @@ final class BreedingOffspringService {
                     context.breedingConfigId(),
                     childCooldown.durationMs(),
                     childSpawnRole.adultRoleId(),
+                    childSpawnRole.gender(),
                     childSpawnRole.lifecycleFamily(),
                     store
             );

--- a/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringSpawnService.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringSpawnService.java
@@ -54,7 +54,15 @@ final class BreedingOffspringSpawnService {
                                        int parentARoleIndex,
                                        int parentBRoleIndex,
                                        @Nullable NPCPlugin npcPlugin) {
-        return resolveSpawnRole(baseRoleId, breedingConfig, parentARoleIndex, parentBRoleIndex, npcPlugin, Math.random());
+        return resolveSpawnRole(
+                baseRoleId,
+                breedingConfig,
+                parentARoleIndex,
+                parentBRoleIndex,
+                npcPlugin,
+                Math.random(),
+                Math.random()
+        );
     }
 
     @Nullable
@@ -64,11 +72,31 @@ final class BreedingOffspringSpawnService {
                                        int parentBRoleIndex,
                                        @Nullable NPCPlugin npcPlugin,
                                        double adultRoleRoll) {
+        return resolveSpawnRole(
+                baseRoleId,
+                breedingConfig,
+                parentARoleIndex,
+                parentBRoleIndex,
+                npcPlugin,
+                adultRoleRoll,
+                Math.random()
+        );
+    }
+
+    @Nullable
+    ResolvedSpawnRole resolveSpawnRole(@Nullable String baseRoleId,
+                                       @Nullable TwBreedingConfig breedingConfig,
+                                       int parentARoleIndex,
+                                       int parentBRoleIndex,
+                                       @Nullable NPCPlugin npcPlugin,
+                                       double adultRoleRoll,
+                                       double genderRoll) {
         ResolvedSpawnRole fromBaseRole = resolveSpawnRoleFromBaseRoleId(
                 baseRoleId,
                 breedingConfig,
                 npcPlugin,
-                adultRoleRoll
+                adultRoleRoll,
+                genderRoll
         );
         if (fromBaseRole != null) {
             return fromBaseRole;
@@ -78,13 +106,14 @@ final class BreedingOffspringSpawnService {
                 parentARoleId,
                 breedingConfig,
                 npcPlugin,
-                adultRoleRoll
+                adultRoleRoll,
+                genderRoll
         );
         if (fromParentAIndex != null) {
             return fromParentAIndex;
         }
         String parentBRoleId = resolveRoleIdFromIndex(parentBRoleIndex, npcPlugin);
-        return resolveSpawnRoleFromBaseRoleId(parentBRoleId, breedingConfig, npcPlugin, adultRoleRoll);
+        return resolveSpawnRoleFromBaseRoleId(parentBRoleId, breedingConfig, npcPlugin, adultRoleRoll, genderRoll);
     }
 
     @Nullable
@@ -126,12 +155,13 @@ final class BreedingOffspringSpawnService {
     private ResolvedSpawnRole resolveSpawnRoleFromBaseRoleId(@Nullable String baseRoleId,
                                                              @Nullable TwBreedingConfig breedingConfig,
                                                              @Nullable NPCPlugin npcPlugin,
-                                                             double adultRoleRoll) {
+                                                             double adultRoleRoll,
+                                                             double genderRoll) {
         if (baseRoleId == null || baseRoleId.isBlank() || npcPlugin == null) {
             return null;
         }
         BreedingOffspringRoleResolver.OffspringRoleSelection selection =
-                roleResolver.selectOffspringRole(baseRoleId, breedingConfig, npcPlugin, adultRoleRoll);
+                roleResolver.selectOffspringRole(baseRoleId, breedingConfig, npcPlugin, adultRoleRoll, genderRoll);
         if (selection == null || selection.roleId() == null || selection.roleId().isBlank()) {
             return null;
         }
@@ -139,7 +169,13 @@ final class BreedingOffspringSpawnService {
         if (roleIndex < 0) {
             return null;
         }
-        return new ResolvedSpawnRole(selection.roleId(), roleIndex, selection.adultRoleId(), selection.lifecycleFamily());
+        return new ResolvedSpawnRole(
+                selection.roleId(),
+                roleIndex,
+                selection.adultRoleId(),
+                selection.gender(),
+                selection.lifecycleFamily()
+        );
     }
 
     @Nullable
@@ -284,6 +320,7 @@ final class BreedingOffspringSpawnService {
     record ResolvedSpawnRole(String roleId,
                              int roleIndex,
                              String adultRoleId,
+                             @Nullable TwBreedingConfig.Gender gender,
                              @Nullable TwBreedingConfig.RoleFamily lifecycleFamily) {
     }
 }

--- a/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingPartnerService.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingPartnerService.java
@@ -7,6 +7,7 @@ import com.alechilles.alecstamework.npc.components.TameworkCommandLinksComponent
 import com.alechilles.alecstamework.npc.components.TameworkOwnerComponent;
 import com.alechilles.alecstamework.npc.progression.CompanionLifeStageService;
 import com.alechilles.alecstamework.npc.progression.BreedingTimeService;
+import com.alechilles.alecstamework.npc.progression.CompanionGenderService;
 import com.hypixel.hytale.component.ArchetypeChunk;
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.ComponentType;
@@ -58,11 +59,21 @@ final class BreedingPartnerService {
         boolean requireWander = pairing == null || pairing.isRequireWanderMode();
         boolean requireTamed = eligibility == null || eligibility.isRequireTamed();
         boolean requireAdult = eligibility == null || eligibility.isRequireAdult();
+        TwBreedingConfig.GenderSettings genderSettings = config != null ? config.resolveGender(sourceRoleId) : null;
+        boolean requireDifferentGender = genderSettings != null
+                && genderSettings.isEnabled()
+                && genderSettings.isRequireDifferentGender();
+        String sourceGender = requireDifferentGender
+                ? CompanionGenderService.resolveGender(sourceRef, store, sourceRoleId, config)
+                : null;
 
         if (requireWander && !isInWanderState(sourceNpc.getRole())) {
             return null;
         }
         if (requireAdult && !CompanionLifeStageService.isAdult(sourceRef, store, sourceRoleId)) {
+            return null;
+        }
+        if (requireDifferentGender && sourceGender == null) {
             return null;
         }
 
@@ -102,6 +113,17 @@ final class BreedingPartnerService {
                 String candidateRoleId = resolveRoleId(candidateNpc);
                 if (!compatibilityService.canPair(sourceRoleId, candidateRoleId, config, pairing)) {
                     continue;
+                }
+                if (requireDifferentGender) {
+                    String candidateGender = CompanionGenderService.resolveGender(
+                            candidateRef,
+                            store,
+                            candidateRoleId,
+                            config
+                    );
+                    if (!CompanionGenderService.different(sourceGender, candidateGender)) {
+                        continue;
+                    }
                 }
                 if (requireAdult && !CompanionLifeStageService.isAdult(candidateRef, store, candidateRoleId)) {
                     continue;

--- a/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingPartnerService.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/actions/BreedingPartnerService.java
@@ -119,7 +119,7 @@ final class BreedingPartnerService {
                             candidateRef,
                             store,
                             candidateRoleId,
-                            config
+                            resolveCandidateConfig(candidateRoleId, config)
                     );
                     if (!CompanionGenderService.different(sourceGender, candidateGender)) {
                         continue;
@@ -161,6 +161,46 @@ final class BreedingPartnerService {
             return null;
         }
         return new PartnerCandidate(best.ref, best.npc, best.breeding, best.roleId, best.ownerId, best.distanceSq);
+    }
+
+    @Nullable
+    static TwBreedingConfig resolveCandidateConfig(@Nullable String candidateRoleId,
+                                                   @Nullable TwBreedingConfig sourceConfig) {
+        TwBreedingConfig candidateConfig = TwBreedingConfig.resolveForRole(candidateRoleId);
+        if (candidateConfig != null) {
+            return candidateConfig;
+        }
+        return configDeclaresRole(sourceConfig, candidateRoleId) ? sourceConfig : null;
+    }
+
+    private static boolean configDeclaresRole(@Nullable TwBreedingConfig config, @Nullable String roleId) {
+        if (config == null || roleId == null || roleId.isBlank()) {
+            return false;
+        }
+        String normalized = normalizeRoleId(roleId);
+        for (String configuredRoleId : config.getRoleIds()) {
+            if (normalized.equals(normalizeRoleId(configuredRoleId))) {
+                return true;
+            }
+        }
+        for (String overrideRoleId : config.getRoleOverrides().keySet()) {
+            if (normalized.equals(normalizeRoleId(overrideRoleId))) {
+                return true;
+            }
+        }
+        return config.resolveLifecycleFamilyForRole(roleId) != null;
+    }
+
+    private static String normalizeRoleId(@Nullable String roleId) {
+        if (roleId == null) {
+            return "";
+        }
+        String normalized = roleId.trim().toLowerCase(Locale.ROOT);
+        int separator = normalized.lastIndexOf(':');
+        if (separator >= 0 && separator < normalized.length() - 1) {
+            return normalized.substring(separator + 1);
+        }
+        return normalized;
     }
 
     private static boolean sameOwner(@Nullable UUID sourceOwnerId, @Nullable UUID candidateOwnerId) {

--- a/src/main/java/com/alechilles/alecstamework/npc/components/TameworkLifeStageComponent.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/components/TameworkLifeStageComponent.java
@@ -106,6 +106,12 @@ public final class TameworkLifeStageComponent implements Component<EntityStore> 
             TameworkLifeStageComponent::getAdolescentRoleId
         )
         .add()
+        .append(
+            new KeyedCodec<>("Gender", Codec.STRING),
+            TameworkLifeStageComponent::setGender,
+            TameworkLifeStageComponent::getGender
+        )
+        .add()
         .build();
 
     private String stage = "Adult";
@@ -123,6 +129,7 @@ public final class TameworkLifeStageComponent implements Component<EntityStore> 
     private String adultRoleId;
     private String babyRoleId;
     private String adolescentRoleId;
+    private String gender;
 
     public TameworkLifeStageComponent() {
     }
@@ -278,6 +285,14 @@ public final class TameworkLifeStageComponent implements Component<EntityStore> 
         this.adolescentRoleId = adolescentRoleId;
     }
 
+    public String getGender() {
+        return gender;
+    }
+
+    public void setGender(String gender) {
+        this.gender = gender;
+    }
+
     @Override
     public TameworkLifeStageComponent clone() {
         TameworkLifeStageComponent clone = new TameworkLifeStageComponent(
@@ -297,6 +312,7 @@ public final class TameworkLifeStageComponent implements Component<EntityStore> 
         clone.setAdultRoleId(adultRoleId);
         clone.setBabyRoleId(babyRoleId);
         clone.setAdolescentRoleId(adolescentRoleId);
+        clone.setGender(gender);
         return clone;
     }
 }

--- a/src/main/java/com/alechilles/alecstamework/npc/progression/CompanionGenderService.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/progression/CompanionGenderService.java
@@ -1,0 +1,196 @@
+package com.alechilles.alecstamework.npc.progression;
+
+import com.alechilles.alecstamework.config.assets.TwBreedingConfig;
+import com.alechilles.alecstamework.npc.components.TameworkLifeStageComponent;
+import com.hypixel.hytale.component.ComponentType;
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import com.hypixel.hytale.server.npc.entities.NPCEntity;
+import java.util.Locale;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+/**
+ * Resolves and persists optional binary companion gender state from breeding config.
+ */
+public final class CompanionGenderService {
+    public static final String MALE = "Male";
+    public static final String FEMALE = "Female";
+
+    private CompanionGenderService() {
+    }
+
+    @Nullable
+    public static String ensureGender(@Nullable Ref<EntityStore> npcRef,
+                                      @Nullable Store<EntityStore> store,
+                                      @Nullable String roleIdHint) {
+        return ensureGender(npcRef, store, roleIdHint, null, null);
+    }
+
+    @Nullable
+    public static String ensureGender(@Nullable Ref<EntityStore> npcRef,
+                                      @Nullable Store<EntityStore> store,
+                                      @Nullable String roleIdHint,
+                                      @Nullable TwBreedingConfig configHint,
+                                      @Nullable TwBreedingConfig.Gender preferredGender) {
+        if (npcRef == null || !npcRef.isValid() || store == null) {
+            return null;
+        }
+        String roleId = firstNonBlank(roleIdHint, CompanionRoleIdResolver.resolveRoleId(npcRef, store));
+        TwBreedingConfig config = configHint != null
+                ? configHint
+                : roleId != null ? TwBreedingConfig.resolveForRole(roleId) : null;
+        TwBreedingConfig.GenderSettings settings = config != null ? config.resolveGender(roleId) : null;
+        if (settings == null || !settings.isEnabled()) {
+            return null;
+        }
+        ComponentType<EntityStore, TameworkLifeStageComponent> type = TameworkLifeStageComponent.getComponentType();
+        if (type == null) {
+            return null;
+        }
+        TameworkLifeStageComponent component = store.getComponent(npcRef, type);
+        if (component == null) {
+            return null;
+        }
+        String existing = normalizeGender(component.getGender());
+        if (existing != null) {
+            return existing;
+        }
+        String resolved = preferredGender != null
+                ? preferredGender.toConfigValue()
+                : resolveGender(npcRef, store, roleId, config);
+        if (resolved == null) {
+            return null;
+        }
+        component.setGender(resolved);
+        store.putComponent(npcRef, type, component);
+        return resolved;
+    }
+
+    @Nullable
+    public static String resolveGender(@Nullable Ref<EntityStore> npcRef,
+                                       @Nullable Store<EntityStore> store,
+                                       @Nullable String roleIdHint,
+                                       @Nullable TwBreedingConfig config) {
+        if (npcRef == null || !npcRef.isValid() || store == null) {
+            return null;
+        }
+        String roleId = firstNonBlank(roleIdHint, CompanionRoleIdResolver.resolveRoleId(npcRef, store));
+        TwBreedingConfig effectiveConfig = config != null
+                ? config
+                : roleId != null ? TwBreedingConfig.resolveForRole(roleId) : null;
+        TwBreedingConfig.GenderSettings settings = effectiveConfig != null
+                ? effectiveConfig.resolveGender(roleId)
+                : null;
+        if (settings == null || !settings.isEnabled()) {
+            return null;
+        }
+        ComponentType<EntityStore, TameworkLifeStageComponent> type = TameworkLifeStageComponent.getComponentType();
+        TameworkLifeStageComponent component = type != null ? store.getComponent(npcRef, type) : null;
+        String existing = component != null ? normalizeGender(component.getGender()) : null;
+        if (existing != null) {
+            return existing;
+        }
+        TwBreedingConfig.Gender roleGender = resolveRoleGender(effectiveConfig, roleId, component);
+        if (roleGender != null) {
+            return roleGender.toConfigValue();
+        }
+        return settings.selectGender(stableGenderRoll(npcRef, store)).toConfigValue();
+    }
+
+    @Nullable
+    public static String normalizeGender(@Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        TwBreedingConfig.Gender gender = TwBreedingConfig.Gender.fromConfigValue(value.trim());
+        return gender == null ? null : gender.toConfigValue();
+    }
+
+    public static boolean different(@Nullable String left, @Nullable String right) {
+        String normalizedLeft = normalizeGender(left);
+        String normalizedRight = normalizeGender(right);
+        return normalizedLeft != null && normalizedRight != null && !normalizedLeft.equals(normalizedRight);
+    }
+
+    @Nullable
+    private static TwBreedingConfig.Gender resolveRoleGender(@Nullable TwBreedingConfig config,
+                                                            @Nullable String roleId,
+                                                            @Nullable TameworkLifeStageComponent component) {
+        if (config == null) {
+            return null;
+        }
+        TwBreedingConfig.RoleFamily family = null;
+        if (roleId != null && !roleId.isBlank()) {
+            family = config.resolveLifecycleFamilyForRole(roleId);
+            if (family != null) {
+                TwBreedingConfig.Gender gender = family.resolveGenderForAdultRole(roleId);
+                if (gender != null) {
+                    return gender;
+                }
+            }
+        }
+        String adultRoleId = component != null ? component.getAdultRoleId() : null;
+        if (adultRoleId != null && !adultRoleId.isBlank()) {
+            if (family == null) {
+                family = config.resolveLifecycleFamilyForRole(adultRoleId);
+            }
+            if (family != null) {
+                return family.resolveGenderForAdultRole(adultRoleId);
+            }
+        }
+        return null;
+    }
+
+    private static double stableGenderRoll(@Nullable Ref<EntityStore> npcRef, @Nullable Store<EntityStore> store) {
+        long seed = 0L;
+        if (npcRef != null && npcRef.isValid() && store != null) {
+            NPCEntity npc = store.getComponent(npcRef, NPCEntity.getComponentType());
+            UUID uuid = npc != null ? npc.getUuid() : null;
+            if (uuid != null) {
+                seed = uuid.getMostSignificantBits() ^ Long.rotateLeft(uuid.getLeastSignificantBits(), 17);
+            }
+        }
+        if (seed == 0L) {
+            seed = 0x5DEECE66DL;
+        }
+        long mixed = mix64(seed);
+        long positive = mixed >>> 11;
+        return positive * 0x1.0p-53;
+    }
+
+    private static long mix64(long value) {
+        long z = value + 0x9E3779B97F4A7C15L;
+        z = (z ^ (z >>> 30)) * 0xBF58476D1CE4E5B9L;
+        z = (z ^ (z >>> 27)) * 0x94D049BB133111EBL;
+        return z ^ (z >>> 31);
+    }
+
+    @Nullable
+    private static String firstNonBlank(@Nullable String first, @Nullable String second) {
+        if (first != null && !first.isBlank()) {
+            return first.trim();
+        }
+        if (second != null && !second.isBlank()) {
+            return second.trim();
+        }
+        return null;
+    }
+
+    @Nullable
+    public static String toDisplayLabel(@Nullable String gender) {
+        String normalized = normalizeGender(gender);
+        if (normalized == null) {
+            return null;
+        }
+        String lower = normalized.toLowerCase(Locale.ROOT);
+        if ("male".equals(lower)) {
+            return MALE;
+        }
+        if ("female".equals(lower)) {
+            return FEMALE;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/alechilles/alecstamework/npc/progression/CompanionProgressionBootstrapService.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/progression/CompanionProgressionBootstrapService.java
@@ -77,6 +77,7 @@ public final class CompanionProgressionBootstrapService {
         double nextSizeMultiplier = resolveSizeMultiplier(npcRef, store, traitConfig);
         CompanionStatModifierService.applyTraitModifiers(npcRef, store);
         CompanionLifeStageService.ensureLifeStageComponent(npcRef, store, roleId);
+        CompanionGenderService.ensureGender(npcRef, store, roleId);
         CompanionLifeStageService.applySizeMultiplierDelta(
                 npcRef,
                 store,

--- a/src/test/java/com/alechilles/alecstamework/config/assets/TwBreedingConfigInheritanceTest.java
+++ b/src/test/java/com/alechilles/alecstamework/config/assets/TwBreedingConfigInheritanceTest.java
@@ -81,6 +81,51 @@ class TwBreedingConfigInheritanceTest {
                 child.getPairing().getRoleCompatibility());
     }
 
+    @Test
+    void genderSectionInheritsMissingNestedKeys() throws Exception {
+        TwBreedingConfig parent = new TwBreedingConfig();
+        TwBreedingConfig child = new TwBreedingConfig();
+
+        TwBreedingConfig.GenderSettings parentGender = new TwBreedingConfig.GenderSettings();
+        TwBreedingConfig.GenderSettings childGender = new TwBreedingConfig.GenderSettings();
+        setField(parentGender, "enabled", true);
+        setField(parentGender, "maleWeight", 2.0);
+        setField(parentGender, "femaleWeight", 3.0);
+        setField(childGender, "enabled", false);
+        setField(childGender, "femaleWeight", 4.0);
+        setField(parent, "gender", parentGender);
+        setField(child, "gender", childGender);
+
+        Map<String, Set<String>> nested = new HashMap<>();
+        nested.put("Gender", Set.of("FemaleWeight"));
+        child.inheritMissingTopLevelFrom(parent, Set.of("Gender"), nested);
+
+        assertTrue(child.getGender().isEnabled());
+        assertEquals(2.0, child.getGender().getMaleWeight(), 0.000001);
+        assertEquals(4.0, child.getGender().getFemaleWeight(), 0.000001);
+    }
+
+    @Test
+    void genderCanBeOverriddenPerRole() throws Exception {
+        TwBreedingConfig config = new TwBreedingConfig();
+        TwBreedingConfig.GenderSettings gender = new TwBreedingConfig.GenderSettings();
+        TwBreedingConfig.RoleOverrideSettings roleOverride = new TwBreedingConfig.RoleOverrideSettings();
+        TwBreedingConfig.GenderSettingsOverride genderOverride = new TwBreedingConfig.GenderSettingsOverride();
+        Map<String, TwBreedingConfig.RoleOverrideSettings> overrides = new HashMap<>();
+        overrides.put("Tamed_Deer_Stag", roleOverride);
+
+        setField(gender, "enabled", false);
+        setField(gender, "maleWeight", 1.0);
+        setField(genderOverride, "enabled", true);
+        setField(genderOverride, "maleWeight", 4.0);
+        setField(roleOverride, "gender", genderOverride);
+        setField(config, "gender", gender);
+        setField(config, "roleOverrides", overrides);
+
+        assertTrue(config.resolveGender("Tamed_Deer_Stag").isEnabled());
+        assertEquals(4.0, config.resolveGender("Tamed_Deer_Stag").getMaleWeight(), 0.000001);
+    }
+
     private static void setField(Object target, String fieldName, Object value) throws Exception {
         Field field = target.getClass().getDeclaredField(fieldName);
         field.setAccessible(true);

--- a/src/test/java/com/alechilles/alecstamework/config/assets/TwNamesConfigTest.java
+++ b/src/test/java/com/alechilles/alecstamework/config/assets/TwNamesConfigTest.java
@@ -53,6 +53,18 @@ class TwNamesConfigTest {
         );
     }
 
+    @Test
+    void genderPoolUsesMatchingNameSectionsOnly() throws Exception {
+        TwNamesConfig config = new TwNamesConfig();
+        setField(config, "northAmericaMale", new String[] { "Noah" });
+        setField(config, "northAmericaFemale", new String[] { "Emma" });
+        setField(config, "germanMale", new String[] { "Felix" });
+        setField(config, "germanFemale", new String[] { "Mia" });
+
+        assertArrayEquals(new String[] { "Noah", "Felix" }, config.getMergedPool("Male"));
+        assertArrayEquals(new String[] { "Emma", "Mia" }, config.getMergedPool("Female"));
+    }
+
     private static void setField(Object target, String name, Object value) throws Exception {
         Field field = target.getClass().getDeclaredField(name);
         field.setAccessible(true);

--- a/src/test/java/com/alechilles/alecstamework/npc/actions/BreedingAdultRoleSelectionServiceTest.java
+++ b/src/test/java/com/alechilles/alecstamework/npc/actions/BreedingAdultRoleSelectionServiceTest.java
@@ -53,6 +53,27 @@ class BreedingAdultRoleSelectionServiceTest {
         assertEquals("Legacy_Deer", service.selectAdultRole(family, null, 0.50));
     }
 
+    @Test
+    void genderedAdultSelectionUsesMatchingChoices() throws Exception {
+        TwBreedingConfig.RoleFamily family = weightedFamily(
+                adultRole("Deer_Stag", 1.0, TwBreedingConfig.Gender.Male),
+                adultRole("Deer_Doe", 10.0, TwBreedingConfig.Gender.Female)
+        );
+
+        assertEquals("Deer_Stag", service.selectAdultRole(family, null, 0.99, TwBreedingConfig.Gender.Male));
+        assertEquals("Deer_Doe", service.selectAdultRole(family, null, 0.0, TwBreedingConfig.Gender.Female));
+    }
+
+    @Test
+    void genderedAdultSelectionFallsBackToUngenderedChoicesWhenNeeded() throws Exception {
+        TwBreedingConfig.RoleFamily family = weightedFamily(
+                adultRole("Deer_Stag", 1.0, TwBreedingConfig.Gender.Male),
+                adultRole("Deer_Adult", 1.0)
+        );
+
+        assertEquals("Deer_Adult", service.selectAdultRole(family, null, 0.50, TwBreedingConfig.Gender.Female));
+    }
+
     private static TwBreedingConfig.RoleFamily weightedFamily(TwBreedingConfig.AdultRoleChoice... choices)
             throws Exception {
         TwBreedingConfig.RoleFamily family = new TwBreedingConfig.RoleFamily();
@@ -62,9 +83,16 @@ class BreedingAdultRoleSelectionServiceTest {
     }
 
     private static TwBreedingConfig.AdultRoleChoice adultRole(String roleId, double weight) throws Exception {
+        return adultRole(roleId, weight, null);
+    }
+
+    private static TwBreedingConfig.AdultRoleChoice adultRole(String roleId,
+                                                             double weight,
+                                                             TwBreedingConfig.Gender gender) throws Exception {
         TwBreedingConfig.AdultRoleChoice choice = new TwBreedingConfig.AdultRoleChoice();
         setField(choice, "roleId", roleId);
         setField(choice, "weight", weight);
+        setField(choice, "gender", gender);
         return choice;
     }
 

--- a/src/test/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringRoleResolverTest.java
+++ b/src/test/java/com/alechilles/alecstamework/npc/actions/BreedingOffspringRoleResolverTest.java
@@ -1,0 +1,62 @@
+package com.alechilles.alecstamework.npc.actions;
+
+import com.alechilles.alecstamework.config.assets.TwBreedingConfig;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Regression coverage for offspring role and gender reconciliation. */
+class BreedingOffspringRoleResolverTest {
+
+    @Test
+    void selectedAdultRoleGenderOverridesSampledGender() throws Exception {
+        TwBreedingConfig.RoleFamily family = weightedFamily(
+                adultRole("Deer_Stag", TwBreedingConfig.Gender.Male)
+        );
+
+        assertEquals(
+                TwBreedingConfig.Gender.Male,
+                BreedingOffspringRoleResolver.resolveSelectedGender(
+                        family,
+                        "Deer_Stag",
+                        TwBreedingConfig.Gender.Female
+                )
+        );
+    }
+
+    @Test
+    void sampledGenderIsKeptWhenAdultRoleHasNoGender() throws Exception {
+        TwBreedingConfig.RoleFamily family = weightedFamily(adultRole("Deer_Adult", null));
+
+        assertEquals(
+                TwBreedingConfig.Gender.Female,
+                BreedingOffspringRoleResolver.resolveSelectedGender(
+                        family,
+                        "Deer_Adult",
+                        TwBreedingConfig.Gender.Female
+                )
+        );
+    }
+
+    private static TwBreedingConfig.RoleFamily weightedFamily(TwBreedingConfig.AdultRoleChoice... choices)
+            throws Exception {
+        TwBreedingConfig.RoleFamily family = new TwBreedingConfig.RoleFamily();
+        setField(family, "adultRoles", choices);
+        return family;
+    }
+
+    private static TwBreedingConfig.AdultRoleChoice adultRole(String roleId,
+                                                             TwBreedingConfig.Gender gender) throws Exception {
+        TwBreedingConfig.AdultRoleChoice choice = new TwBreedingConfig.AdultRoleChoice();
+        setField(choice, "roleId", roleId);
+        setField(choice, "gender", gender);
+        return choice;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/src/test/java/com/alechilles/alecstamework/npc/actions/BreedingPartnerServiceTest.java
+++ b/src/test/java/com/alechilles/alecstamework/npc/actions/BreedingPartnerServiceTest.java
@@ -1,0 +1,51 @@
+package com.alechilles.alecstamework.npc.actions;
+
+import com.alechilles.alecstamework.config.assets.TwBreedingConfig;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/** Regression coverage for partner-specific gender config resolution. */
+class BreedingPartnerServiceTest {
+
+    @Test
+    void candidateConfigDoesNotFallBackToSourceConfigForUnrelatedRole() throws Exception {
+        TwBreedingConfig sourceConfig = configWithRoles("SourceRole");
+
+        assertNull(BreedingPartnerService.resolveCandidateConfig("OtherRole", sourceConfig));
+    }
+
+    @Test
+    void candidateConfigCanUseSourceConfigWhenSourceDeclaresCandidateRole() throws Exception {
+        TwBreedingConfig sourceConfig = configWithRoles("SourceRole", "OtherRole");
+
+        assertSame(sourceConfig, BreedingPartnerService.resolveCandidateConfig("mods:OtherRole", sourceConfig));
+    }
+
+    @Test
+    void candidateConfigCanUseSourceConfigWhenLifecycleDeclaresCandidateRole() throws Exception {
+        TwBreedingConfig sourceConfig = configWithRoles("SourceRole");
+        TwBreedingConfig.RoleFamily family = new TwBreedingConfig.RoleFamily();
+        setField(family, "adultRoleId", "OtherRole");
+        setField(sourceConfig.getOffspringLifecycle(), "families", new TwBreedingConfig.RoleFamily[] { family });
+
+        assertSame(sourceConfig, BreedingPartnerService.resolveCandidateConfig("mods:OtherRole", sourceConfig));
+    }
+
+    private static TwBreedingConfig configWithRoles(String... roleIds) throws Exception {
+        Constructor<TwBreedingConfig> constructor = TwBreedingConfig.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        TwBreedingConfig config = constructor.newInstance();
+        setField(config, "roleIds", roleIds);
+        return config;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/wiki/Modder-Documentation/Config-Reference/TwBreedingConfig-Reference.md
+++ b/wiki/Modder-Documentation/Config-Reference/TwBreedingConfig-Reference.md
@@ -45,6 +45,7 @@ Use it when you want to control:
   "Cooldowns": { "...": "..." },
   "PassiveBreeding": { "...": "..." },
   "Timing": { "...": "..." },
+  "Gender": { "...": "..." },
   "Inheritance": { "...": "..." },
   "OffspringLifecycle": { "...": "..." },
   "RoleOverrides": {
@@ -109,6 +110,16 @@ Accepted values for both timing sections:
 - `REAL_TIME`
 - `WORLD_TIME_SCALED`
 
+### `Gender`
+Controls optional binary gender assignment and partner filtering. Omit this section, or set `Enabled` to `false`, to preserve existing ungendered behavior.
+
+- `Enabled`: assigns stable `Male` or `Female` gender to companions covered by this breeding config.
+- `RequireDifferentGender`: when enabled, breeding partners must have different assigned genders.
+- `MaleWeight`: relative chance for a generated companion to be assigned `Male`.
+- `FemaleWeight`: relative chance for a generated companion to be assigned `Female`.
+
+When `OffspringLifecycle.Families[].AdultRoles[]` entries include `Gender`, offspring select a matching future adult role when possible. If no matching gendered choice is selectable, Tamework falls back to the normal weighted adult-role list so older mixed configs still work.
+
 ### `Inheritance`
 - `InheritOwner`
 - `InheritTamed`
@@ -163,8 +174,8 @@ Use a family entry when one adult role, or a set of related adult roles, should 
 ```json
 {
   "AdultRoles": [
-    { "RoleId": "Deer_Stag", "Weight": 1.0 },
-    { "RoleId": "Deer_Doe", "Weight": 1.0 }
+    { "RoleId": "Deer_Stag", "Gender": "Male", "Weight": 1.0 },
+    { "RoleId": "Deer_Doe", "Gender": "Female", "Weight": 1.0 }
   ],
   "BabyRoleId": "Deer_Fawn"
 }
@@ -187,6 +198,7 @@ Invalid, blank, or non-positive weighted adult entries are ignored for selection
 - `Cooldowns`
 - `PassiveBreeding`
 - `Timing`
+- `Gender`
 - `Inheritance`
 - `OffspringLifecycle`
 
@@ -296,7 +308,7 @@ Important behavior:
 ```
 
 ## Cross-Role Family Example
-This pattern allows two different adult roles to breed together, produce one shared baby role, and grow into one of the configured adult roles. Use `SameLifecycleFamily` instead when same-role pairs in the family should also be valid.
+This pattern allows two different adult roles to breed together, produce one shared baby role, and grow into one of the configured adult roles. Gender is optional; this example enables it so stag/doe pairs are required and offspring grow into an adult role matching the assigned gender. Use `SameLifecycleFamily` instead when same-role pairs in the family should also be valid.
 
 ```json
 {
@@ -312,14 +324,20 @@ This pattern allows two different adult roles to breed together, produce one sha
     "RequireSameOwner": false,
     "MaxNearbySameType": 8
   },
+  "Gender": {
+    "Enabled": true,
+    "RequireDifferentGender": true,
+    "MaleWeight": 1.0,
+    "FemaleWeight": 1.0
+  },
   "OffspringLifecycle": {
     "Enabled": true,
     "DefaultTimeToFullGrownMinutes": 48,
     "Families": [
       {
         "AdultRoles": [
-          { "RoleId": "Deer_Stag", "Weight": 1.0 },
-          { "RoleId": "Deer_Doe", "Weight": 1.0 }
+          { "RoleId": "Deer_Stag", "Gender": "Male", "Weight": 1.0 },
+          { "RoleId": "Deer_Doe", "Gender": "Female", "Weight": 1.0 }
         ],
         "BabyRoleId": "Deer_Fawn"
       }
@@ -333,6 +351,7 @@ This pattern allows two different adult roles to breed together, produce one sha
 - Explicit `Families` or `RoleMaxNearbySameType` arrays replace the parent list.
 - Keep `Timing.Basis` and `PassiveBreeding.Basis` intentional. They solve different timing problems.
 - New content should prefer minute-based keys where they exist, but old second-based keys remain valid.
+- Gender labels appear in linked companion panels and preserved spawner tooltips for companions covered by an enabled gender config.
 
 ## Related Pages
 - [Progression Systems Guide](/mod/alecs-tamework/progression-systems-guide)

--- a/wiki/Modder-Documentation/Config-Reference/TwNamesConfig-Reference.md
+++ b/wiki/Modder-Documentation/Config-Reference/TwNamesConfig-Reference.md
@@ -45,6 +45,7 @@ Each top-level key is a pool id. Each value is a string array of candidate names
 Behavior:
 - If the id resolves to a non-empty pool, naming UI randomize is enabled.
 - If it is missing or empty, manual naming still works.
+- When an NPC has gender from an enabled `TwBreedingConfig.Gender` section, randomization prefers matching `...Male` or `...Female` pool sections. Ungendered NPCs keep the existing merged-pool behavior.
 
 ## Minimal Example
 ```json


### PR DESCRIPTION
## Summary
- add optional `TwBreedingConfig.Gender` settings with inheritance and per-role overrides
- persist companion gender through lifecycle state, offspring spawning, and spawner metadata
- apply gender-aware breeding partner filtering, adult-role selection, linked panel/spawner tooltip display, and random name pools
- document the new breeding JSON shape and add changelog coverage

## Validation
- `./mvnw.cmd test` (486 tests passing)
- `rg "PlayerRef\.getComponent\(Player|getComponent\(Player\.getComponentType\(\)\)|Universe\.get\(\).*getPlayers" -n src/main/java` (only existing non-tick event-holder access in `CommandItemFeatureHandler`)
- `git diff --cached --check`