### PR TITLE
Add custom trait effect API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Added a public Trait Effects API so integrations can register custom `TwTraitConfig` effect keys and execute them during Tamework's existing trait-effect resyncs.
+
 ## 2.9.0 - Companion Controls, Gender Breeding, and Embedded Telemetry - 2026-05-04
 
 ### Added

--- a/src/main/java/com/alechilles/alecstamework/Tamework.java
+++ b/src/main/java/com/alechilles/alecstamework/Tamework.java
@@ -15,6 +15,8 @@ import com.alechilles.alecstamework.api.internal.InteractionExtensionRegistry;
 import com.alechilles.alecstamework.api.internal.InteractionExtensionRuntime;
 import com.alechilles.alecstamework.api.internal.TameworkApiImpl;
 import com.alechilles.alecstamework.api.internal.TameworkEventBus;
+import com.alechilles.alecstamework.api.internal.TraitEffectRegistry;
+import com.alechilles.alecstamework.api.internal.TraitEffectRuntime;
 import com.alechilles.alecstamework.assets.TameworkAssetPackCoordinator;
 import com.alechilles.alecstamework.commands.TameworkCommandRoot;
 import com.alechilles.alecstamework.config.CommandItemRegistry;
@@ -187,6 +189,7 @@ public class Tamework extends JavaPlugin {
     private TameworkApi api;
     private TameworkEventBus apiEventBus;
     private InteractionExtensionRegistry interactionExtensionRegistry;
+    private TraitEffectRegistry traitEffectRegistry;
     private ApiSelfTestFixtureManager apiSelfTestFixtureManager;
     private ApiSelfTestRunner apiSelfTestRunner;
     private TameworkNpcBuilderRegistrar npcBuilderRegistrar;
@@ -590,6 +593,7 @@ public class Tamework extends JavaPlugin {
         persistenceRuntime = TameworkPersistenceRuntime.initialize(runtimeDataDirectory, getLogger());
         apiEventBus = new TameworkEventBus(getLogger());
         interactionExtensionRegistry = new InteractionExtensionRegistry(getLogger());
+        traitEffectRegistry = new TraitEffectRegistry(getLogger(), persistenceRuntime.getNpcProfileRepository());
         persistenceRuntime.getNpcProfileRepository().setChangeObserver(apiEventBus);
         commandLinkedNpcStateSnapshotService = new CommandLinkedNpcStateSnapshotService(
                 persistenceRuntime.getNpcProfileRepository()
@@ -598,7 +602,8 @@ public class Tamework extends JavaPlugin {
                 persistenceRuntime,
                 apiEventBus,
                 commandLinkedNpcStateSnapshotService,
-                interactionExtensionRegistry
+                interactionExtensionRegistry,
+                traitEffectRegistry
         );
         apiSelfTestFixtureManager = new ApiSelfTestFixtureManager(persistenceRuntime);
         apiSelfTestRunner = new ApiSelfTestRunner();
@@ -1074,6 +1079,11 @@ public class Tamework extends JavaPlugin {
     @Nullable
     public InteractionExtensionRuntime getInteractionExtensionRuntime() {
         return interactionExtensionRegistry;
+    }
+
+    @Nullable
+    public TraitEffectRuntime getTraitEffectRuntime() {
+        return traitEffectRegistry;
     }
 
     @Nullable

--- a/src/main/java/com/alechilles/alecstamework/api/TameworkApi.java
+++ b/src/main/java/com/alechilles/alecstamework/api/TameworkApi.java
@@ -17,6 +17,8 @@ public interface TameworkApi {
 
     InteractionExtensionApi interactionExtensions();
 
+    TraitEffectApi traitEffects();
+
     ProfileDataApi profileData();
 
     TameworkEventsApi events();

--- a/src/main/java/com/alechilles/alecstamework/api/TameworkApiCapability.java
+++ b/src/main/java/com/alechilles/alecstamework/api/TameworkApiCapability.java
@@ -7,6 +7,7 @@ public enum TameworkApiCapability {
     PROGRESSION_MUTATIONS,
     POLICY,
     INTERACTION_EXTENSIONS,
+    TRAIT_EFFECTS,
     PROFILE_DATA,
     EVENTS,
     CONFIG_READ,

--- a/src/main/java/com/alechilles/alecstamework/api/TraitEffectApi.java
+++ b/src/main/java/com/alechilles/alecstamework/api/TraitEffectApi.java
@@ -1,0 +1,23 @@
+package com.alechilles.alecstamework.api;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+/**
+ * Public registry for custom trait effect keys consumed during Tamework trait resyncs.
+ */
+public interface TraitEffectApi {
+    /**
+     * Registers an idempotent handler for a trait effect key.
+     *
+     * @return a handle that unregisters this exact handler when closed.
+     */
+    @Nonnull
+    AutoCloseable registerEffectKey(@Nonnull String effectKey, @Nonnull TraitEffectHandler handler);
+
+    /**
+     * Lists normalized effect keys that currently have registered handlers.
+     */
+    @Nonnull
+    Set<String> listEffectKeys();
+}

--- a/src/main/java/com/alechilles/alecstamework/api/TraitEffectContext.java
+++ b/src/main/java/com/alechilles/alecstamework/api/TraitEffectContext.java
@@ -1,0 +1,28 @@
+package com.alechilles.alecstamework.api;
+
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import java.util.List;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Runtime context passed to custom trait effect handlers during trait resync.
+ */
+public record TraitEffectContext(
+        @Nonnull String effectKey,
+        double value,
+        @Nonnull List<TraitEffectContribution> contributions,
+        @Nonnull Ref<EntityStore> npcRef,
+        @Nonnull Store<EntityStore> store,
+        @Nullable UUID npcUuid,
+        @Nullable String profileId,
+        @Nullable String roleId,
+        @Nullable String traitConfigId
+) {
+    public TraitEffectContext {
+        contributions = List.copyOf(contributions);
+    }
+}

--- a/src/main/java/com/alechilles/alecstamework/api/TraitEffectContribution.java
+++ b/src/main/java/com/alechilles/alecstamework/api/TraitEffectContribution.java
@@ -1,0 +1,15 @@
+package com.alechilles.alecstamework.api;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Describes one active trait that contributed to a custom trait effect value.
+ */
+public record TraitEffectContribution(
+        @Nonnull String traitId,
+        @Nullable String displayName,
+        double value,
+        @Nonnull String effectKey
+) {
+}

--- a/src/main/java/com/alechilles/alecstamework/api/TraitEffectHandler.java
+++ b/src/main/java/com/alechilles/alecstamework/api/TraitEffectHandler.java
@@ -1,0 +1,11 @@
+package com.alechilles.alecstamework.api;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Handles a resolved trait effect value for a registered custom effect key.
+ */
+@FunctionalInterface
+public interface TraitEffectHandler {
+    boolean apply(@Nonnull TraitEffectContext context);
+}

--- a/src/main/java/com/alechilles/alecstamework/api/internal/TameworkApiImpl.java
+++ b/src/main/java/com/alechilles/alecstamework/api/internal/TameworkApiImpl.java
@@ -27,6 +27,7 @@ import com.alechilles.alecstamework.api.TameworkApi;
 import com.alechilles.alecstamework.api.TameworkApiCapability;
 import com.alechilles.alecstamework.api.TameworkConfigReadApi;
 import com.alechilles.alecstamework.api.TameworkEventsApi;
+import com.alechilles.alecstamework.api.TraitEffectApi;
 import com.alechilles.alecstamework.api.Vector3View;
 import com.alechilles.alecstamework.config.ItemFeatureRegistry;
 import com.alechilles.alecstamework.config.assets.TwBreedingConfig;
@@ -105,7 +106,7 @@ import javax.annotation.Nullable;
 
 public final class TameworkApiImpl
         implements TameworkApi, NpcProfilesApi, ProfileDataApi, TameworkConfigReadApi, PolicyApi, DiagnosticsApi {
-    static final String API_VERSION = "0.4.0";
+    static final String API_VERSION = "0.5.0";
     static final String RESERVED_NAMESPACE = "Alechilles:Tamework";
     private static final String SNAPSHOT_CAPTURE = "capture";
     private static final String SNAPSHOT_DEATH = "death";
@@ -120,6 +121,7 @@ public final class TameworkApiImpl
     private final CommandLinkedNpcStateSnapshotService stateSnapshotService;
     private final SimpleClaimsBreedingBridge simpleClaimsBridge;
     private final InteractionExtensionApi interactionExtensionApi;
+    private final TraitEffectApi traitEffectApi;
     private final CommandLinksApi commandLinksApi = new CommandLinksApi() {
         @Override
         public Optional<CommandLinkView> getByProfileId(String profileId) {
@@ -254,6 +256,7 @@ public final class TameworkApiImpl
             TameworkApiCapability.PROGRESSION_MUTATIONS,
             TameworkApiCapability.POLICY,
             TameworkApiCapability.INTERACTION_EXTENSIONS,
+            TameworkApiCapability.TRAIT_EFFECTS,
             TameworkApiCapability.PROFILE_DATA,
             TameworkApiCapability.EVENTS,
             TameworkApiCapability.CONFIG_READ,
@@ -264,7 +267,8 @@ public final class TameworkApiImpl
     public TameworkApiImpl(@Nonnull TameworkPersistenceRuntime persistenceRuntime,
                            @Nonnull TameworkEventBus eventBus,
                            @Nullable CommandLinkedNpcStateSnapshotService stateSnapshotService,
-                           @Nonnull InteractionExtensionApi interactionExtensionApi) {
+                           @Nonnull InteractionExtensionApi interactionExtensionApi,
+                           @Nonnull TraitEffectApi traitEffectApi) {
         this.persistenceRuntime = Objects.requireNonNull(persistenceRuntime);
         this.profileRepository = Objects.requireNonNull(persistenceRuntime.getNpcProfileRepository());
         this.profileDataRepository = Objects.requireNonNull(persistenceRuntime.getApiProfileDataRepository());
@@ -272,6 +276,7 @@ public final class TameworkApiImpl
         this.stateSnapshotService = stateSnapshotService;
         this.simpleClaimsBridge = SimpleClaimsBreedingBridge.initialize();
         this.interactionExtensionApi = Objects.requireNonNull(interactionExtensionApi);
+        this.traitEffectApi = Objects.requireNonNull(traitEffectApi);
     }
 
     @Override
@@ -307,6 +312,11 @@ public final class TameworkApiImpl
     @Override
     public InteractionExtensionApi interactionExtensions() {
         return interactionExtensionApi;
+    }
+
+    @Override
+    public TraitEffectApi traitEffects() {
+        return traitEffectApi;
     }
 
     @Override

--- a/src/main/java/com/alechilles/alecstamework/api/internal/TraitEffectRegistry.java
+++ b/src/main/java/com/alechilles/alecstamework/api/internal/TraitEffectRegistry.java
@@ -1,0 +1,257 @@
+package com.alechilles.alecstamework.api.internal;
+
+import com.alechilles.alecstamework.api.TraitEffectApi;
+import com.alechilles.alecstamework.api.TraitEffectContext;
+import com.alechilles.alecstamework.api.TraitEffectContribution;
+import com.alechilles.alecstamework.api.TraitEffectHandler;
+import com.alechilles.alecstamework.config.assets.TwTraitConfig;
+import com.alechilles.alecstamework.npc.components.TameworkTraitsComponent;
+import com.alechilles.alecstamework.npc.progression.CompanionRoleIdResolver;
+import com.alechilles.alecstamework.persistence.sqlite.NpcProfileRepository;
+import com.hypixel.hytale.component.ComponentType;
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.logger.HytaleLogger;
+import com.hypixel.hytale.server.core.entity.UUIDComponent;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Stores public custom trait-effect handlers and applies them from Tamework trait resyncs.
+ */
+public final class TraitEffectRegistry implements TraitEffectApi, TraitEffectRuntime {
+    @Nullable
+    private final HytaleLogger logger;
+    @Nullable
+    private final NpcProfileRepository profileRepository;
+    private final ConcurrentHashMap<String, TraitEffectHandler> handlers = new ConcurrentHashMap<>();
+
+    public TraitEffectRegistry(@Nullable HytaleLogger logger, @Nullable NpcProfileRepository profileRepository) {
+        this.logger = logger;
+        this.profileRepository = profileRepository;
+    }
+
+    @Override
+    @Nonnull
+    public AutoCloseable registerEffectKey(@Nonnull String effectKey, @Nonnull TraitEffectHandler handler) {
+        String normalizedKey = requireNormalizedKey(effectKey);
+        TraitEffectHandler normalizedHandler = Objects.requireNonNull(handler, "handler");
+        handlers.put(normalizedKey, normalizedHandler);
+        return () -> handlers.remove(normalizedKey, normalizedHandler);
+    }
+
+    @Override
+    @Nonnull
+    public Set<String> listEffectKeys() {
+        return Set.copyOf(handlers.keySet());
+    }
+
+    @Override
+    public void applyRegisteredEffects(@Nullable Ref<EntityStore> npcRef, @Nullable Store<EntityStore> store) {
+        if (npcRef == null || store == null || !npcRef.isValid() || handlers.isEmpty()) {
+            return;
+        }
+        ComponentType<EntityStore, TameworkTraitsComponent> type = TameworkTraitsComponent.getComponentType();
+        TameworkTraitsComponent component = type != null ? store.getComponent(npcRef, type) : null;
+        String roleId = CompanionRoleIdResolver.resolveRoleId(npcRef, store);
+        TwTraitConfig config = resolveTraitConfig(component, roleId);
+        String traitConfigId = resolveTraitConfigId(component, config);
+        UUID npcUuid = resolveNpcUuid(npcRef, store);
+        String profileId = resolveProfileId(npcUuid);
+
+        for (Map.Entry<String, TraitEffectHandler> entry : handlers.entrySet()) {
+            String effectKey = entry.getKey();
+            ResolvedTraitEffect resolved = resolveEffect(effectKey, component, config);
+            TraitEffectContext context = new TraitEffectContext(
+                    effectKey,
+                    resolved.value(),
+                    resolved.contributions(),
+                    npcRef,
+                    store,
+                    npcUuid,
+                    profileId,
+                    roleId,
+                    traitConfigId
+            );
+            invokeHandler(effectKey, entry.getValue(), context);
+        }
+    }
+
+    @Nonnull
+    static ResolvedTraitEffect resolveEffect(@Nullable String effectKey,
+                                             @Nullable TameworkTraitsComponent component,
+                                             @Nullable TwTraitConfig config) {
+        String normalizedEffectKey = normalize(effectKey);
+        if (component == null || config == null || normalizedEffectKey == null) {
+            return ResolvedTraitEffect.empty();
+        }
+        Map<String, TwTraitConfig.TraitDefinition> definitionById = buildDefinitionMap(config);
+        if (definitionById.isEmpty()) {
+            return ResolvedTraitEffect.empty();
+        }
+
+        double multiplier = 1.0;
+        ArrayList<TraitEffectContribution> contributions = new ArrayList<>();
+        for (TameworkTraitsComponent.TraitValue value : component.getTraitValues()) {
+            if (value == null) {
+                continue;
+            }
+            String normalizedId = normalize(value.getId());
+            if (normalizedId == null) {
+                continue;
+            }
+            TwTraitConfig.TraitDefinition definition = definitionById.get(normalizedId);
+            if (definition == null) {
+                continue;
+            }
+            String definitionEffect = definition.getEffectKey();
+            String normalizedDefinitionEffect = normalize(definitionEffect);
+            if (!normalizedEffectKey.equals(normalizedDefinitionEffect)) {
+                continue;
+            }
+            double traitValue = value.getValue();
+            if (!Double.isFinite(traitValue)) {
+                continue;
+            }
+            multiplier *= traitValue;
+            contributions.add(new TraitEffectContribution(
+                    definition.getId(),
+                    definition.getDisplayName(),
+                    traitValue,
+                    definitionEffect
+            ));
+        }
+        if (contributions.isEmpty()) {
+            return ResolvedTraitEffect.empty();
+        }
+        return new ResolvedTraitEffect(multiplier, contributions);
+    }
+
+    @Nonnull
+    private String requireNormalizedKey(@Nullable String rawKey) {
+        String normalized = normalize(rawKey);
+        if (normalized == null) {
+            throw new IllegalArgumentException("effect key must be nonblank.");
+        }
+        return normalized;
+    }
+
+    @Nullable
+    private static String normalize(@Nullable String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return null;
+        }
+        return rawValue.trim().toLowerCase(Locale.ROOT);
+    }
+
+    @Nullable
+    private static TwTraitConfig resolveTraitConfig(@Nullable TameworkTraitsComponent component,
+                                                    @Nullable String roleId) {
+        if (roleId != null && !roleId.isBlank()) {
+            TwTraitConfig byRole = TwTraitConfig.resolveForRole(roleId);
+            if (byRole != null) {
+                return byRole;
+            }
+        }
+        if (component == null) {
+            return null;
+        }
+        String configId = component.getConfigId();
+        if (configId == null || configId.isBlank()) {
+            return null;
+        }
+        return TwTraitConfig.resolveById(configId);
+    }
+
+    @Nullable
+    private static String resolveTraitConfigId(@Nullable TameworkTraitsComponent component,
+                                               @Nullable TwTraitConfig config) {
+        if (config != null && config.getId() != null && !config.getId().isBlank()) {
+            return config.getId();
+        }
+        if (component != null && component.getConfigId() != null && !component.getConfigId().isBlank()) {
+            return component.getConfigId();
+        }
+        return null;
+    }
+
+    @Nullable
+    private static UUID resolveNpcUuid(@Nonnull Ref<EntityStore> npcRef, @Nonnull Store<EntityStore> store) {
+        ComponentType<EntityStore, UUIDComponent> uuidType = UUIDComponent.getComponentType();
+        if (uuidType == null) {
+            return null;
+        }
+        UUIDComponent uuidComponent = store.getComponent(npcRef, uuidType);
+        return uuidComponent != null ? uuidComponent.getUuid() : null;
+    }
+
+    @Nullable
+    private String resolveProfileId(@Nullable UUID npcUuid) {
+        if (npcUuid == null || profileRepository == null) {
+            return null;
+        }
+        return profileRepository.resolveProfileId(npcUuid);
+    }
+
+    private static Map<String, TwTraitConfig.TraitDefinition> buildDefinitionMap(TwTraitConfig config) {
+        HashMap<String, TwTraitConfig.TraitDefinition> map = new HashMap<>();
+        for (TwTraitConfig.TraitDefinition definition : config.getTraits()) {
+            if (definition == null) {
+                continue;
+            }
+            String normalized = normalize(definition.getId());
+            if (normalized == null || map.containsKey(normalized)) {
+                continue;
+            }
+            map.put(normalized, definition);
+        }
+        return map;
+    }
+
+    boolean invokeHandler(@Nonnull String effectKey,
+                          @Nonnull TraitEffectHandler handler,
+                          @Nonnull TraitEffectContext context) {
+        try {
+            return handler.apply(context);
+        } catch (Throwable error) {
+            logHandlerFailure(effectKey, error);
+            return false;
+        }
+    }
+
+    private void logHandlerFailure(@Nonnull String effectKey, @Nullable Throwable error) {
+        if (logger == null) {
+            return;
+        }
+        String message = "Tamework trait effect handler failed: " + effectKey;
+        if (error == null) {
+            logger.at(Level.WARNING).log(message);
+        } else {
+            logger.at(Level.WARNING).withCause(error).log(message);
+        }
+    }
+
+    record ResolvedTraitEffect(double value, @Nonnull List<TraitEffectContribution> contributions) {
+        private static final ResolvedTraitEffect EMPTY = new ResolvedTraitEffect(1.0, List.of());
+
+        @Nonnull
+        static ResolvedTraitEffect empty() {
+            return EMPTY;
+        }
+
+        ResolvedTraitEffect {
+            contributions = List.copyOf(contributions);
+        }
+    }
+}

--- a/src/main/java/com/alechilles/alecstamework/api/internal/TraitEffectRuntime.java
+++ b/src/main/java/com/alechilles/alecstamework/api/internal/TraitEffectRuntime.java
@@ -1,0 +1,13 @@
+package com.alechilles.alecstamework.api.internal;
+
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import javax.annotation.Nullable;
+
+/**
+ * Internal bridge used by Tamework runtime systems to execute registered trait effects.
+ */
+public interface TraitEffectRuntime {
+    void applyRegisteredEffects(@Nullable Ref<EntityStore> npcRef, @Nullable Store<EntityStore> store);
+}

--- a/src/main/java/com/alechilles/alecstamework/npc/progression/CompanionTraitEffectService.java
+++ b/src/main/java/com/alechilles/alecstamework/npc/progression/CompanionTraitEffectService.java
@@ -1,6 +1,7 @@
 package com.alechilles.alecstamework.npc.progression;
 
 import com.alechilles.alecstamework.Tamework;
+import com.alechilles.alecstamework.api.internal.TraitEffectRuntime;
 import com.hypixel.hytale.assetstore.map.IndexedLookupTableAssetMap;
 import com.hypixel.hytale.component.ComponentType;
 import com.hypixel.hytale.component.Ref;
@@ -31,6 +32,18 @@ public final class CompanionTraitEffectService {
             return;
         }
         applyMoveSpeedEffect(npcRef, store);
+        applyRegisteredTraitEffects(npcRef, store);
+    }
+
+    private static void applyRegisteredTraitEffects(Ref<EntityStore> npcRef, Store<EntityStore> store) {
+        Tamework instance = Tamework.getInstance();
+        if (instance == null) {
+            return;
+        }
+        TraitEffectRuntime runtime = instance.getTraitEffectRuntime();
+        if (runtime != null) {
+            runtime.applyRegisteredEffects(npcRef, store);
+        }
     }
 
     private static void applyMoveSpeedEffect(Ref<EntityStore> npcRef, Store<EntityStore> store) {

--- a/src/main/java/com/alechilles/alecstamework/selftest/ApiSelfTestRunner.java
+++ b/src/main/java/com/alechilles/alecstamework/selftest/ApiSelfTestRunner.java
@@ -24,6 +24,7 @@ import com.alechilles.alecstamework.api.SpawnerConfigView;
 import com.alechilles.alecstamework.api.TameworkApi;
 import com.alechilles.alecstamework.api.TameworkApiCapability;
 import com.alechilles.alecstamework.api.TameworkConfigReadApi;
+import com.alechilles.alecstamework.api.TraitEffectApi;
 import com.alechilles.alecstamework.api.Vector3View;
 import com.alechilles.alecstamework.npc.progression.CompanionProgressionBootstrapService;
 import com.hypixel.hytale.component.Ref;
@@ -56,6 +57,7 @@ public final class ApiSelfTestRunner {
         CONFIGS,
         PROGRESSION,
         INTERACTION_EXTENSIONS,
+        TRAIT_EFFECTS,
         POLICIES,
         DIAGNOSTICS,
         ALL;
@@ -86,6 +88,9 @@ public final class ApiSelfTestRunner {
         }
         if (suite == Suite.ALL || suite == Suite.INTERACTION_EXTENSIONS) {
             suites.add(runInteractionExtensions(context));
+        }
+        if (suite == Suite.ALL || suite == Suite.TRAIT_EFFECTS) {
+            suites.add(runTraitEffects(context));
         }
         if (suite == Suite.ALL || suite == Suite.POLICIES) {
             suites.add(runPolicies(context));
@@ -705,6 +710,47 @@ public final class ApiSelfTestRunner {
         }
         assertions.add(check("blank preset id rejected", invalidPresetRejected, Boolean.toString(invalidPresetRejected)));
         return new ApiSelfTestSuiteResult("interaction-extensions", assertions);
+    }
+
+    @Nonnull
+    private ApiSelfTestSuiteResult runTraitEffects(@Nonnull ApiSelfTestContext context) {
+        ArrayList<ApiSelfTestAssertion> assertions = new ArrayList<>();
+        TraitEffectApi traitEffects = context.api().traitEffects();
+        if (traitEffects == null) {
+            assertions.add(fail("trait effect api available", "<null>"));
+            return new ApiSelfTestSuiteResult("trait-effects", assertions);
+        }
+
+        String idSuffix = UUID.randomUUID().toString().replace("-", "");
+        String effectKey = "selftest.trait.effect." + idSuffix;
+        AutoCloseable registration = null;
+        try {
+            registration = traitEffects.registerEffectKey(effectKey.toUpperCase(Locale.ROOT), traitContext -> true);
+            assertions.add(check(
+                    "registered trait effect key is listed",
+                    traitEffects.listEffectKeys().contains(effectKey),
+                    "effects=" + traitEffects.listEffectKeys()
+            ));
+        } catch (Exception ex) {
+            assertions.add(fail("trait effect registration", ex.getClass().getSimpleName() + ": " + ex.getMessage()));
+        } finally {
+            closeQuietly(registration);
+        }
+
+        assertions.add(check(
+                "trait effect key unregistered on close",
+                !traitEffects.listEffectKeys().contains(effectKey),
+                "effects=" + traitEffects.listEffectKeys()
+        ));
+
+        boolean invalidEffectRejected = false;
+        try {
+            traitEffects.registerEffectKey(" ", traitContext -> true);
+        } catch (IllegalArgumentException expected) {
+            invalidEffectRejected = true;
+        }
+        assertions.add(check("blank trait effect key rejected", invalidEffectRejected, Boolean.toString(invalidEffectRejected)));
+        return new ApiSelfTestSuiteResult("trait-effects", assertions);
     }
 
     @Nonnull

--- a/src/test/java/com/alechilles/alecstamework/api/internal/TameworkApiImplTest.java
+++ b/src/test/java/com/alechilles/alecstamework/api/internal/TameworkApiImplTest.java
@@ -43,10 +43,11 @@ class TameworkApiImplTest {
                     runtime,
                     bus,
                     stateSnapshotService,
-                    new InteractionExtensionRegistry(null)
+                    new InteractionExtensionRegistry(null),
+                    new TraitEffectRegistry(null, runtime.getNpcProfileRepository())
             );
 
-            assertEquals("0.4.0", api.getApiVersion());
+            assertEquals("0.5.0", api.getApiVersion());
             assertEquals(
                     EnumSet.of(
                             TameworkApiCapability.PROFILES,
@@ -55,6 +56,7 @@ class TameworkApiImplTest {
                             TameworkApiCapability.PROGRESSION_MUTATIONS,
                             TameworkApiCapability.POLICY,
                             TameworkApiCapability.INTERACTION_EXTENSIONS,
+                            TameworkApiCapability.TRAIT_EFFECTS,
                             TameworkApiCapability.PROFILE_DATA,
                             TameworkApiCapability.EVENTS,
                             TameworkApiCapability.CONFIG_READ,
@@ -88,6 +90,7 @@ class TameworkApiImplTest {
             assertEquals(profileId, byNpcUuid.orElseThrow().profileId());
             assertTrue(api.progression().getByProfileId(profileId).isEmpty());
             assertTrue(api.progression().getByNpcUuid(npcUuid).isEmpty());
+            assertNotNull(api.traitEffects());
             assertEquals(
                     ProgressionMutationStatus.NOT_LOADED,
                     api.progression().setHappiness(profileId, 75.0).status()

--- a/src/test/java/com/alechilles/alecstamework/api/internal/TraitEffectRegistryTest.java
+++ b/src/test/java/com/alechilles/alecstamework/api/internal/TraitEffectRegistryTest.java
@@ -1,0 +1,146 @@
+package com.alechilles.alecstamework.api.internal;
+
+import com.alechilles.alecstamework.api.TraitEffectContext;
+import com.alechilles.alecstamework.api.TraitEffectContribution;
+import com.alechilles.alecstamework.config.assets.TwTraitConfig;
+import com.alechilles.alecstamework.npc.components.TameworkTraitsComponent;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraitEffectRegistryTest {
+    @Test
+    void registersListsReplacesClosesAndRejectsBlankKeys() throws Exception {
+        TraitEffectRegistry registry = new TraitEffectRegistry(null, null);
+        AutoCloseable first = registry.registerEffectKey("Example.Genetics:ScalePattern", context -> true);
+
+        assertEquals(1, registry.listEffectKeys().size());
+        assertTrue(registry.listEffectKeys().contains("example.genetics:scalepattern"));
+
+        AutoCloseable second = registry.registerEffectKey("example.genetics:scalepattern", context -> true);
+        assertEquals(1, registry.listEffectKeys().size());
+
+        first.close();
+        assertTrue(registry.listEffectKeys().contains("example.genetics:scalepattern"));
+
+        second.close();
+        assertFalse(registry.listEffectKeys().contains("example.genetics:scalepattern"));
+        assertThrows(IllegalArgumentException.class, () -> registry.registerEffectKey("   ", context -> true));
+        assertThrows(NullPointerException.class, () -> registry.registerEffectKey("example.valid", null));
+    }
+
+    @Test
+    void handlerFailuresAreCaughtAndReturnFalse() {
+        TraitEffectRegistry registry = new TraitEffectRegistry(null, null);
+        TraitEffectContext context = new TraitEffectContext(
+                "throwing.effect",
+                1.0,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertFalse(registry.invokeHandler("throwing.effect", ignored -> {
+            throw new IllegalStateException("boom");
+        }, context));
+    }
+
+    @Test
+    void resolveEffectCombinesMatchingTraitValuesAndContributorDetails() throws Exception {
+        TwTraitConfig config = createConfig(
+                trait("Trait_Scale", "Scale Pattern", "Example.Genetics:ScalePattern"),
+                trait("Trait_Pattern", "Pattern", "example.genetics:scalepattern"),
+                trait("Trait_Other", "Other", "OtherEffect"),
+                trait("Trait_Nan", "Bad", "Example.Genetics:ScalePattern"),
+                trait("Trait_Infinite", "Bad Infinite", "Example.Genetics:ScalePattern"),
+                trait("Trait_Blank", "Blank", " ")
+        );
+        TameworkTraitsComponent component = new TameworkTraitsComponent(
+                "Traits_Test",
+                123L,
+                new TameworkTraitsComponent.TraitValue[] {
+                        new TameworkTraitsComponent.TraitValue("Trait_Scale", 1.2),
+                        new TameworkTraitsComponent.TraitValue("trait_pattern", 0.5),
+                        new TameworkTraitsComponent.TraitValue("Trait_Other", 3.0),
+                        new TameworkTraitsComponent.TraitValue("Trait_Missing", 8.0),
+                        new TameworkTraitsComponent.TraitValue("Trait_Nan", Double.NaN),
+                        new TameworkTraitsComponent.TraitValue("Trait_Infinite", Double.POSITIVE_INFINITY),
+                        new TameworkTraitsComponent.TraitValue("Trait_Blank", 9.0)
+                }
+        );
+
+        TraitEffectRegistry.ResolvedTraitEffect resolved =
+                TraitEffectRegistry.resolveEffect("example.genetics:scalepattern", component, config);
+        List<TraitEffectContribution> contributions = resolved.contributions();
+
+        assertEquals(0.6, resolved.value(), 0.000001);
+        assertEquals(2, contributions.size());
+        assertEquals("Trait_Scale", contributions.get(0).traitId());
+        assertEquals("Scale Pattern", contributions.get(0).displayName());
+        assertEquals(1.2, contributions.get(0).value(), 0.000001);
+        assertEquals("Example.Genetics:ScalePattern", contributions.get(0).effectKey());
+        assertEquals("Trait_Pattern", contributions.get(1).traitId());
+        assertEquals("Pattern", contributions.get(1).displayName());
+        assertEquals(0.5, contributions.get(1).value(), 0.000001);
+    }
+
+    @Test
+    void resolveEffectReturnsDefaultWhenRegisteredKeyHasNoContributors() throws Exception {
+        TwTraitConfig config = createConfig(
+                trait("Trait_Other", "Other", "OtherEffect")
+        );
+        TameworkTraitsComponent component = new TameworkTraitsComponent(
+                "Traits_Test",
+                123L,
+                new TameworkTraitsComponent.TraitValue[] {
+                        new TameworkTraitsComponent.TraitValue("Trait_Other", 2.0)
+                }
+        );
+
+        TraitEffectRegistry.ResolvedTraitEffect resolved =
+                TraitEffectRegistry.resolveEffect("example.genetics:scalepattern", component, config);
+
+        assertEquals(1.0, resolved.value(), 0.000001);
+        assertTrue(resolved.contributions().isEmpty());
+    }
+
+    private TwTraitConfig createConfig(TwTraitConfig.TraitDefinition... definitions) throws Exception {
+        Constructor<TwTraitConfig> ctor = TwTraitConfig.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        TwTraitConfig config = ctor.newInstance();
+        setField(config, "id", "Traits_Test");
+        setField(config, "enabled", true);
+        setField(config, "traits", definitions);
+        return config;
+    }
+
+    private TwTraitConfig.TraitDefinition trait(String id, String displayName, String effectKey) throws Exception {
+        TwTraitConfig.TraitDefinition definition = new TwTraitConfig.TraitDefinition();
+        setField(definition, "id", id);
+        setField(definition, "displayName", displayName);
+        setField(definition, "effectKey", effectKey);
+        setField(definition, "weight", 1.0);
+        setField(definition, "naturalMin", 1.0);
+        setField(definition, "naturalMax", 1.0);
+        setField(definition, "breedingMin", 1.0);
+        setField(definition, "breedingMax", 1.0);
+        setField(definition, "defaultValue", 1.0);
+        return definition;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/wiki/Modder-Documentation/Config-Reference/TwTraitConfig-Reference.md
+++ b/wiki/Modder-Documentation/Config-Reference/TwTraitConfig-Reference.md
@@ -186,11 +186,12 @@ Authoring guidance:
 
 ## Gotchas
 - `Traits` is an explicit array. Child assets replace the entire parent list when they author it.
-- `EffectKey` is runtime-coupled. Only keys consumed by Tamework or your own downstream logic will do anything.
+- `EffectKey` is runtime-coupled. Built-in keys work automatically, custom keys only do something when a mod registers a matching Trait Effects API handler, and unregistered keys are inert.
 - Broken or missing `IconPath` values do not stop the trait from working, but the UI will fall back instead of showing the intended icon.
 
 ## Related Pages
 - [Progression Systems Guide](/mod/alecs-tamework/progression-systems-guide)
+- [Trait Effects API Reference](/mod/alecs-tamework/trait-effects-api-reference)
 - [TwBreedingConfig Reference](/mod/alecs-tamework/twbreedingconfig-reference)
 - [TwHappinessConfig Reference](/mod/alecs-tamework/twhappinessconfig-reference)
 

--- a/wiki/Modder-Documentation/Public-API/API-Recipes/API-Bootstrap-and-Capability-Checks-Recipe.md
+++ b/wiki/Modder-Documentation/Public-API/API-Recipes/API-Bootstrap-and-Capability-Checks-Recipe.md
@@ -23,7 +23,7 @@ if (api == null) {
     return; // Tamework not loaded or API unavailable
 }
 
-if (!"0.4.0".equals(api.getApiVersion())) {
+if (!"0.5.0".equals(api.getApiVersion())) {
     // Optional: warn, then continue with capability-based gating
 }
 

--- a/wiki/Modder-Documentation/Public-API/API-Recipes/In-Game-API-Self-Test-Smoke-Recipe.md
+++ b/wiki/Modder-Documentation/Public-API/API-Recipes/In-Game-API-Self-Test-Smoke-Recipe.md
@@ -21,6 +21,7 @@ Goal: run the built-in in-game API smoke flow against a live server.
 ```text
 /tw api test run progression verbose
 /tw api test run interaction-extensions verbose
+/tw api test run trait-effects verbose
 ```
 
 ## Notes

--- a/wiki/Modder-Documentation/Public-API/API-Recipes/Register-Custom-Trait-Effect-Key-Recipe.md
+++ b/wiki/Modder-Documentation/Public-API/API-Recipes/Register-Custom-Trait-Effect-Key-Recipe.md
@@ -1,0 +1,88 @@
+---
+title: "Register Custom Trait Effect Key Recipe"
+order: 18
+published: true
+draft: false
+---
+# Register Custom Trait Effect Key Recipe
+
+Parent: [API Recipes](/mod/alecs-tamework/api-recipes) | [Modder Documentation](/mod/alecs-tamework/modder-documentation)
+
+Goal: register a custom trait effect key and use that key from normal `TwTraitConfig` assets.
+
+## Pattern
+```java
+import com.alechilles.alecstamework.api.TameworkApi;
+import com.alechilles.alecstamework.api.TameworkApiCapability;
+import java.util.EnumSet;
+
+private AutoCloseable scalePatternHandle;
+
+public void onEnable(TameworkApi api) {
+    EnumSet<TameworkApiCapability> capabilities = api.getCapabilities();
+    if (!capabilities.contains(TameworkApiCapability.TRAIT_EFFECTS)) {
+        return;
+    }
+
+    scalePatternHandle = api.traitEffects().registerEffectKey("example.genetics:ScalePattern", context -> {
+        double scalePatternValue = context.value();
+        if (context.contributions().isEmpty()) {
+            geneticsVisualService.clearScalePattern(context.npcRef(), context.store());
+            return true;
+        }
+
+        geneticsVisualService.applyScalePattern(
+                context.npcRef(),
+                context.store(),
+                context.npcUuid(),
+                scalePatternValue
+        );
+        return true;
+    });
+}
+
+public void onDisable() {
+    if (scalePatternHandle != null) {
+        try {
+            scalePatternHandle.close();
+        } catch (Exception ignored) {
+        }
+        scalePatternHandle = null;
+    }
+}
+```
+
+## Trait Config
+Use the same key in normal trait config authoring:
+
+```json
+{
+  "Id": "Traits_Example_Genetics",
+  "RoleIds": [
+    "Mob_Example"
+  ],
+  "Traits": [
+    {
+      "Id": "Trait_ScalePatternWide",
+      "DisplayName": "Wide Scale Pattern",
+      "EffectKey": "example.genetics:ScalePattern",
+      "NaturalMin": 1.1,
+      "NaturalMax": 1.3,
+      "BreedingMin": 0.9,
+      "BreedingMax": 1.5,
+      "Default": 1.0
+    }
+  ]
+}
+```
+
+## Notes
+- Effect keys are case-insensitive and listed in normalized lowercase form.
+- Handlers are called during Tamework's existing trait-effect resyncs, including spawn/bootstrap, world load, API trait mutation, debug trait commands, respawn/capture restore, leveling/talent resyncs, and breeding offspring initialization.
+- Handlers must be idempotent. Tamework may call them repeatedly with the same value.
+- Registered handlers add behavior for custom keys. They do not replace built-in Tamework handling for built-in keys.
+- Unregistered custom keys remain inert even if they appear in `TwTraitConfig`.
+
+## Related Pages
+- [Trait Effects API Reference](/mod/alecs-tamework/trait-effects-api-reference)
+- [TwTraitConfig Reference](/mod/alecs-tamework/twtraitconfig-reference)

--- a/wiki/Modder-Documentation/Public-API/API-Recipes/index.md
+++ b/wiki/Modder-Documentation/Public-API/API-Recipes/index.md
@@ -10,7 +10,7 @@ Parent: [Public API](/mod/alecs-tamework/public-api) | [Modder Documentation](/m
 
 This subsection provides task-focused examples for common Tamework API integration workflows.
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > Recipe behavior should always be gated behind runtime capability checks.
 
 ## Child Pages
@@ -30,6 +30,7 @@ This subsection provides task-focused examples for common Tamework API integrati
 - [Enforce Ownership before Custom Command or Effect Recipe](/mod/alecs-tamework/enforce-ownership-before-custom-command-or-effect-recipe)
 - [Check Population Cap before Spawning or Taming Recipe](/mod/alecs-tamework/check-population-cap-before-spawning-or-taming-recipe)
 - [Register Interaction Extensions in Plugin Lifecycle Recipe](/mod/alecs-tamework/register-interaction-extensions-in-plugin-lifecycle-recipe)
+- [Register Custom Trait Effect Key Recipe](/mod/alecs-tamework/register-custom-trait-effect-key-recipe)
 
 ## Additional Recipes
 - [API Bootstrap and Capability Checks Recipe](/mod/alecs-tamework/api-bootstrap-and-capability-checks-recipe)

--- a/wiki/Modder-Documentation/Public-API/API-Reference/Command-Links-API-Reference.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/Command-Links-API-Reference.md
@@ -8,7 +8,7 @@ draft: false
 
 Parent: [API Reference](/mod/alecs-tamework/api-reference) | [Public API](/mod/alecs-tamework/public-api)
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > This reference tracks the current `commandLinks()` contract in `TameworkApi`.
 
 Capability: `COMMAND_LINKS`

--- a/wiki/Modder-Documentation/Public-API/API-Reference/Config-Reads-API-Reference.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/Config-Reads-API-Reference.md
@@ -8,7 +8,7 @@ draft: false
 
 Parent: [API Reference](/mod/alecs-tamework/api-reference) | [Public API](/mod/alecs-tamework/public-api)
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > This reference tracks the current `configs()` contract in `TameworkApi`.
 
 Capability: `CONFIG_READ`

--- a/wiki/Modder-Documentation/Public-API/API-Reference/Diagnostics-API-Reference.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/Diagnostics-API-Reference.md
@@ -1,6 +1,6 @@
 ---
 title: "Diagnostics API Reference"
-order: 11
+order: 12
 published: true
 draft: false
 ---
@@ -8,7 +8,7 @@ draft: false
 
 Parent: [API Reference](/mod/alecs-tamework/api-reference) | [Public API](/mod/alecs-tamework/public-api)
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > This reference tracks the current `diagnostics()` contract in `TameworkApi`.
 
 Capability: `DIAGNOSTICS`

--- a/wiki/Modder-Documentation/Public-API/API-Reference/Events-API-Reference.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/Events-API-Reference.md
@@ -8,7 +8,7 @@ draft: false
 
 Parent: [API Reference](/mod/alecs-tamework/api-reference) | [Public API](/mod/alecs-tamework/public-api)
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > This reference tracks the current `events()` contract in `TameworkApi`.
 
 Capability: `EVENTS`

--- a/wiki/Modder-Documentation/Public-API/API-Reference/Interaction-Extensions-API-Reference.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/Interaction-Extensions-API-Reference.md
@@ -8,7 +8,7 @@ draft: false
 
 Parent: [API Reference](/mod/alecs-tamework/api-reference) | [Public API](/mod/alecs-tamework/public-api)
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > This reference tracks the current `interactionExtensions()` contract in `TameworkApi`.
 
 Capability: `INTERACTION_EXTENSIONS`

--- a/wiki/Modder-Documentation/Public-API/API-Reference/Policies-API-Reference.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/Policies-API-Reference.md
@@ -8,7 +8,7 @@ draft: false
 
 Parent: [API Reference](/mod/alecs-tamework/api-reference) | [Public API](/mod/alecs-tamework/public-api)
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > This reference tracks the current `policies()` contract in `TameworkApi`.
 
 Capability: `POLICY`

--- a/wiki/Modder-Documentation/Public-API/API-Reference/Profile-Data-API-Reference.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/Profile-Data-API-Reference.md
@@ -8,7 +8,7 @@ draft: false
 
 Parent: [API Reference](/mod/alecs-tamework/api-reference) | [Public API](/mod/alecs-tamework/public-api)
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > This reference tracks the current `profileData()` contract in `TameworkApi`.
 
 Capability: `PROFILE_DATA`

--- a/wiki/Modder-Documentation/Public-API/API-Reference/Profiles-API-Reference.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/Profiles-API-Reference.md
@@ -8,7 +8,7 @@ draft: false
 
 Parent: [API Reference](/mod/alecs-tamework/api-reference) | [Public API](/mod/alecs-tamework/public-api)
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > This reference tracks the current `profiles()` contract in `TameworkApi`.
 
 Capability: `PROFILES`

--- a/wiki/Modder-Documentation/Public-API/API-Reference/Progression-API-Reference.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/Progression-API-Reference.md
@@ -8,7 +8,7 @@ draft: false
 
 Parent: [API Reference](/mod/alecs-tamework/api-reference) | [Public API](/mod/alecs-tamework/public-api)
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > This reference tracks the current `progression()` contract in `TameworkApi`.
 
 Capabilities: `PROGRESSION`, `PROGRESSION_MUTATIONS`

--- a/wiki/Modder-Documentation/Public-API/API-Reference/Public-API-Overview.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/Public-API-Overview.md
@@ -10,7 +10,7 @@ Parent: [API Reference](/mod/alecs-tamework/api-reference) | [Public API](/mod/a
 
 Use this page to bootstrap against `TameworkApi`, verify capabilities, and choose the correct family reference page.
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > The API is named **Public API** in docs and packages, but the contract is still experimental. Keep capability checks and plan for additive changes.
 
 ## Dependency and access pattern
@@ -44,6 +44,7 @@ Root API entrypoints:
 - `progression()`
 - `policies()`
 - `interactionExtensions()`
+- `traitEffects()`
 - `profileData()`
 - `events()`
 - `configs()`
@@ -56,6 +57,7 @@ Current capability set:
 - `PROGRESSION_MUTATIONS`
 - `POLICY`
 - `INTERACTION_EXTENSIONS`
+- `TRAIT_EFFECTS`
 - `PROFILE_DATA`
 - `EVENTS`
 - `CONFIG_READ`
@@ -70,6 +72,7 @@ Current capability set:
 - [Config Reads API Reference](/mod/alecs-tamework/config-reads-api-reference)
 - [Events API Reference](/mod/alecs-tamework/events-api-reference)
 - [Interaction Extensions API Reference](/mod/alecs-tamework/interaction-extensions-api-reference)
+- [Trait Effects API Reference](/mod/alecs-tamework/trait-effects-api-reference)
 - [Diagnostics API Reference](/mod/alecs-tamework/diagnostics-api-reference)
 
 ## Recipes
@@ -89,6 +92,7 @@ Current capability set:
 - [Enforce Ownership before Custom Command or Effect Recipe](/mod/alecs-tamework/enforce-ownership-before-custom-command-or-effect-recipe)
 - [Check Population Cap before Spawning or Taming Recipe](/mod/alecs-tamework/check-population-cap-before-spawning-or-taming-recipe)
 - [Register Interaction Extensions in Plugin Lifecycle Recipe](/mod/alecs-tamework/register-interaction-extensions-in-plugin-lifecycle-recipe)
+- [Register Custom Trait Effect Key Recipe](/mod/alecs-tamework/register-custom-trait-effect-key-recipe)
 - [API Bootstrap and Capability Checks Recipe](/mod/alecs-tamework/api-bootstrap-and-capability-checks-recipe)
 - [Event Subscription Lifecycle Recipe](/mod/alecs-tamework/event-subscription-lifecycle-recipe)
 - [Progression Mutation Status Handling Recipe](/mod/alecs-tamework/progression-mutation-status-handling-recipe)
@@ -107,7 +111,7 @@ See:
 - Do not write directly to `tamework.sqlite`.
 - Do not depend on repository classes like `NpcProfileRepository` or `CaptureRepository`.
 - Do not mutate or cache internal `Tw*Config` instances.
-- Do not assume API version `0.4.0` will match the mod version.
+- Do not assume API version `0.5.0` will match the mod version.
 
 ## Related Pages
 - [Setup and Quick Start](/mod/alecs-tamework/setup-and-quick-start)

--- a/wiki/Modder-Documentation/Public-API/API-Reference/Trait-Effects-API-Reference.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/Trait-Effects-API-Reference.md
@@ -1,0 +1,59 @@
+---
+title: "Trait Effects API Reference"
+order: 11
+published: true
+draft: false
+---
+# Trait Effects API Reference
+
+Parent: [API Reference](/mod/alecs-tamework/api-reference) | [Public API](/mod/alecs-tamework/public-api)
+
+> **Experimental API Contract (`0.5.0`)**
+> This reference tracks the current `traitEffects()` contract in `TameworkApi`.
+
+Capability: `TRAIT_EFFECTS`
+
+## Entry Point
+`TameworkApi.traitEffects() -> TraitEffectApi`
+
+## Methods
+- `AutoCloseable registerEffectKey(String effectKey, TraitEffectHandler handler)`
+- `Set<String> listEffectKeys()`
+
+## ID Rules
+- Effect keys must be nonblank.
+- Effect keys are normalized to lowercase internally.
+- Re-registering the same key replaces the previous handler.
+- Closing the returned `AutoCloseable` unregisters that exact handler.
+- Use namespaced keys, such as `example.genetics:scalepattern`, to avoid collisions.
+
+## Runtime Behavior
+- Tamework calls registered handlers during existing trait-effect resync paths.
+- Built-in Tamework effect keys still run first and are not replaced by registered custom handlers.
+- Handler calls are synchronous on the existing resync path, so keep them fast, idempotent, and main-thread safe.
+- The resolved value is the product of active finite trait values whose `EffectKey` matches the registered key.
+- If a registered key has no active contributing traits, Tamework still calls the handler with `value = 1.0` and an empty contribution list so the handler can clear its own effect.
+- Handler exceptions are caught and logged as warnings; they do not crash the world thread.
+- A handler that returns `false` is treated as unsuccessful but does not interrupt Tamework's own resync.
+
+## Context
+`TraitEffectContext` includes:
+- `effectKey`: the normalized registered effect key.
+- `value`: the resolved multiplier product, or `1.0` when no traits contribute.
+- `contributions`: active `TraitEffectContribution` values.
+- `npcRef` and `store`: the live NPC reference and entity store for main-thread ECS-safe reads/writes.
+- `npcUuid`: the NPC UUID when available.
+- `profileId`: the Tamework profile ID when the NPC has a profile.
+- `roleId`: the resolved NPC role ID when available.
+- `traitConfigId`: the resolved trait config ID when available.
+
+`TraitEffectContribution` includes:
+- `traitId`
+- `displayName`
+- `value`
+- `effectKey`
+
+## Related Pages
+- [Public API Overview](/mod/alecs-tamework/public-api-overview)
+- [TwTraitConfig Reference](/mod/alecs-tamework/twtraitconfig-reference)
+- [Register Custom Trait Effect Key Recipe](/mod/alecs-tamework/register-custom-trait-effect-key-recipe)

--- a/wiki/Modder-Documentation/Public-API/API-Reference/index.md
+++ b/wiki/Modder-Documentation/Public-API/API-Reference/index.md
@@ -10,7 +10,7 @@ Parent: [Public API](/mod/alecs-tamework/public-api) | [Modder Documentation](/m
 
 This subsection contains the reference contract for each public API family.
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > Reference pages describe the current contract and can change while the API remains experimental.
 
 ## Child Pages
@@ -23,6 +23,7 @@ This subsection contains the reference contract for each public API family.
 - [Config Reads API Reference](/mod/alecs-tamework/config-reads-api-reference)
 - [Events API Reference](/mod/alecs-tamework/events-api-reference)
 - [Interaction Extensions API Reference](/mod/alecs-tamework/interaction-extensions-api-reference)
+- [Trait Effects API Reference](/mod/alecs-tamework/trait-effects-api-reference)
 - [Diagnostics API Reference](/mod/alecs-tamework/diagnostics-api-reference)
 
 

--- a/wiki/Modder-Documentation/Public-API/index.md
+++ b/wiki/Modder-Documentation/Public-API/index.md
@@ -10,7 +10,7 @@ Parent: [Modder Documentation](/mod/alecs-tamework/modder-documentation) | [Alec
 
 This subsection is the parent category for all public Java API docs.
 
-> **Experimental API Contract (`0.4.0`)**
+> **Experimental API Contract (`0.5.0`)**
 > This is a public integration surface, but the contract is still experimental. Keep capability checks in downstream mods.
 
 ## Child Pages

--- a/wiki/Modder-Documentation/Testing-and-Diagnostics/In-Game-API-Self-Tests.md
+++ b/wiki/Modder-Documentation/Testing-and-Diagnostics/In-Game-API-Self-Tests.md
@@ -22,7 +22,7 @@ Use the commands in this order:
 Available commands:
 - `/tw api test prepare`
 - `/tw api test status`
-- `/tw api test run [core|profile|command-links|configs|progression|interaction-extensions|policies|diagnostics|all] [verbose]`
+- `/tw api test run [core|profile|command-links|configs|progression|interaction-extensions|trait-effects|policies|diagnostics|all] [verbose]`
 - `/tw api test reset`
 
 These commands are intended for trusted operators and use the `tamework.api.test` permission node with the usual OP/Admin/Operator fallback groups.
@@ -74,6 +74,12 @@ Each fixture is marked with an internal self-test component, linked to the gener
 - id listing and preset lookup behavior
 - unregister behavior via closing returned `AutoCloseable` handles
 - blank-id rejection behavior for requirement/effect/preset registration
+
+`run trait-effects` checks:
+- custom trait effect key registration through the public API
+- normalized key listing behavior
+- unregister behavior via closing the returned `AutoCloseable` handle
+- blank-key rejection behavior
 
 `run policies` checks:
 - ownership reads


### PR DESCRIPTION
## Summary
- add `TameworkApi.traitEffects()` plus the `TRAIT_EFFECTS` capability and API version `0.5.0`
- add public trait effect registration/context/contribution types backed by an internal registry
- invoke registered custom effect keys during existing trait-effect resync paths after built-in Tamework effects
- document the API, recipe, `TwTraitConfig` gotcha, self-test suite, and changelog entry

## Validation
- `./mvnw.cmd "-Dtest=TraitEffectRegistryTest,TameworkApiImplTest" test`
- `./mvnw.cmd test` (`504` tests, `0` failures)
- thread-safety grep from `AGENTS.md`; only the pre-existing `CommandItemFeatureHandler` match was reported
- `git diff --check`